### PR TITLE
add markdown format

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,17 @@
     "meyda": "^5.6.3",
     "mime": "^4.1.0",
     "pdftoimg-js": "^0.2.5",
+    "rehype-parse": "^9.0.1",
+    "rehype-remark": "^10.0.1",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "remark-stringify": "^11.0.0",
     "three": "^0.182.0",
     "three-bvh-csg": "^0.0.17",
     "three-mesh-bvh": "^0.9.8",
+    "unified": "^11.0.5",
     "vite-plugin-static-copy": "^3.1.6",
     "wavefile": "^11.0.0"
   }

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -11,6 +11,7 @@ import svgForeignObjectHandler from "./svgForeignObject.ts";
 import qoiFuHandler from "./qoi-fu.ts";
 import sppdHandler from "./sppd.ts";
 import threejsHandler from "./threejs.ts";
+import markdownHandler from "./markdown.ts";
 
 const handlers: FormatHandler[] = [];
 try { handlers.push(new canvasToBlobHandler()) } catch (_) { };
@@ -25,5 +26,5 @@ try { handlers.push(new svgForeignObjectHandler()) } catch (_) { };
 try { handlers.push(new qoiFuHandler()) } catch (_) { };
 try { handlers.push(new sppdHandler()) } catch (_) { };
 try { handlers.push(new threejsHandler()) } catch (_) { };
-
+try { handlers.push(new markdownHandler()) } catch (_) { };
 export default handlers;

--- a/src/handlers/markdown.ts
+++ b/src/handlers/markdown.ts
@@ -1,0 +1,92 @@
+import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
+import { unified, type Processor } from "unified";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import rehypeStringify from "rehype-stringify";
+import rehypeParse from "rehype-parse";
+import rehypeRemark from "rehype-remark";
+import remarkStringify from "remark-stringify";
+import remarkGfm from "remark-gfm";
+
+class markdownHandler implements FormatHandler {
+
+  public name = "markdown";
+  public supportedFormats = [
+    {
+      name: "Markdown Document",
+      format: "md",
+      extension: "md",
+      mime: "text/markdown",
+      from: true,
+      to: true,
+      internal: "md"
+    },
+    {
+      name: "HyperText Markup Language",
+      format: "html",
+      extension: "html",
+      mime: "text/html",
+      from: true,
+      to: true,
+      internal: "html"
+    }
+  ];
+  public ready = false;
+
+  private htmlToMarkdownPipeline?: Processor<any, any, any, any, string>;
+  private markdownToHtmlPipeline?: Processor<any, any, any, any, string>;
+
+  async init() {
+    this.markdownToHtmlPipeline = unified()
+      .use(remarkParse)
+      .use(remarkGfm)
+      .use(remarkRehype)
+      .use(rehypeStringify);
+    this.htmlToMarkdownPipeline = unified()
+      .use(rehypeParse)
+      .use(rehypeRemark)
+      .use(remarkGfm)
+      .use(remarkStringify);
+    this.ready = true;
+  }
+
+  async doConvert(
+    inputFiles: FileData[],
+    inputFormat: FileFormat,
+    outputFormat: FileFormat
+  ): Promise<FileData[]> {
+    const outputFiles: FileData[] = [];
+
+    if (!this.htmlToMarkdownPipeline || !this.markdownToHtmlPipeline) {
+      throw "Handler not initialized.";
+    }
+
+    for (const file of inputFiles) {
+      const inputText = new TextDecoder().decode(file.bytes);
+      let outputText: string;
+
+      if (inputFormat.internal === "md" && outputFormat.internal === "html") {
+        const result = await this.markdownToHtmlPipeline!.process(inputText);
+        outputText = result.toString();
+      } else if (inputFormat.internal === "html" && outputFormat.internal === "md") {
+        const result = await this.htmlToMarkdownPipeline!.process(inputText);
+        outputText = result.toString();
+      } else {
+        throw "Invalid output format.";
+      }
+
+      const outputBytes = new TextEncoder().encode(outputText);
+      const outputName = file.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension;
+
+      outputFiles.push({
+        name: outputName,
+        bytes: new Uint8Array(outputBytes)
+      });
+    }
+
+    return outputFiles;
+  }
+
+}
+
+export default markdownHandler;


### PR DESCRIPTION
Closes #25

add HTML <-> Markdown and HTML <-> Markdown convention with the packages from the [unified ecosystem](https://unifiedjs.com/). I had to add a lot of npm packages, but they are all really small and do one small thing.