### PR TITLE
Fixed a issue where a browser error was thrown when a svg was passed into canvasToBlob

### DIFF
--- a/src/handlers/canvasToBlob.ts
+++ b/src/handlers/canvasToBlob.ts
@@ -108,7 +108,11 @@ class canvasToBlobHandler implements FormatHandler {
       } else {
 
         const blob = new Blob([inputFile.bytes as BlobPart], { type: inputFormat.mime });
-        const url = URL.createObjectURL(blob);
+        // For SVG, convert to data URL to avoid "Tainted canvases may not be exported" error
+        const url =
+          inputFormat.mime === "image/svg+xml"
+            ? `data:${inputFormat.mime};base64,${btoa(String.fromCharCode(...inputFile.bytes))}`
+            : URL.createObjectURL(blob);
 
         const image = new Image();
         await new Promise((resolve, reject) => {


### PR DESCRIPTION
This fixes a issue where `SecurityError: Failed to execute 'toBlob' on 'HTMLCanvasElement': Tainted canvases may not be exported.` was thrown when a SVG was passed into  the canvasToBlob handler.

To fixe the issue SVG files are converted into a DataURL instead of a ObjectURL.