### PR TITLE
Hotfix: disable unused handlers and update tsconfig exclusions

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -6,25 +6,24 @@ import FFmpegHandler from "./FFmpeg.ts";
 import pdftoimgHandler from "./pdftoimg.ts";
 import ImageMagickHandler from "./ImageMagick.ts";
 import renameHandler from "./rename.ts";
-import envelopeHandler from "./envelope.ts";
+// import envelopeHandler from "./envelope.ts"; // Disabled - missing dependencies
 import svgForeignObjectHandler from "./svgForeignObject.ts";
-import qoiFuHandler from "./qoi-fu.ts";
-import sppdHandler from "./sppd.ts";
+// import qoiFuHandler from "./qoi-fu.ts"; // Disabled - missing package
+// import sppdHandler from "./sppd.ts"; // Disabled - missing files
 import threejsHandler from "./threejs.ts";
 import markdownHandler from "./markdown.ts";
 
 const handlers: FormatHandler[] = [];
-try { handlers.push(new canvasToBlobHandler()) } catch (_) { };
 try { handlers.push(new canvasToBlobHandler()) } catch (_) { };
 try { handlers.push(new meydaHandler()) } catch (_) { };
 try { handlers.push(new FFmpegHandler()) } catch (_) { };
 try { handlers.push(new pdftoimgHandler()) } catch (_) { };
 try { handlers.push(new ImageMagickHandler()) } catch (_) { };
 try { handlers.push(new renameHandler()) } catch (_) { };
-try { handlers.push(new envelopeHandler()) } catch (_) { };
+// try { handlers.push(new envelopeHandler()) } catch (_) { }; // Disabled
 try { handlers.push(new svgForeignObjectHandler()) } catch (_) { };
-try { handlers.push(new qoiFuHandler()) } catch (_) { };
-try { handlers.push(new sppdHandler()) } catch (_) { };
+// try { handlers.push(new qoiFuHandler()) } catch (_) { }; // Disabled
+// try { handlers.push(new sppdHandler()) } catch (_) { }; // Disabled
 try { handlers.push(new threejsHandler()) } catch (_) { };
 try { handlers.push(new markdownHandler()) } catch (_) { };
 export default handlers;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,9 @@
   ],
   "exclude": [
     "src/handlers/qoi-fu/**/*",
-    "src/handlers/sppd/**/*"
+    "src/handlers/sppd/**/*",
+    "src/handlers/envelope.ts",
+    "src/handlers/qoi-fu.ts",
+    "src/handlers/sppd.ts"
   ]
 }


### PR DESCRIPTION
Fixing error


Build logs:

PS C:\Users\benne\Documents\Projekte\convert> bun run build
$ tsc && vite build
vite v7.3.1 building client environment for production...
✓ 427 modules transformed.
computing gzip size (5)...[vite-plugin-static-copy] Copied 3 items.
dist/index.html                                      1.44 kB │ gzip:   0.60 kB
dist/assets/worker-BAOIWoxA.js                       2.53 kB
dist/assets/favicon-Bfod-rsk.ico                    67.65 kB
dist/assets/index-j4D1RWJ8.css                       2.49 kB │ gzip:   0.83 kB
dist/assets/__vite-browser-external-BIHI7g3E.js      0.03 kB │ gzip:   0.05 kB
dist/assets/index-B9fWrEk-.js                        6.12 kB │ gzip:   2.29 kB
dist/assets/pdf-Bq9F7uPV.js                        364.53 kB │ gzip: 109.94 kB
dist/assets/index-BAYMm_pw.js                    1,269.27 kB │ gzip: 354.56 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 5.87s
PS C:\Users\benne\Documents\Projekte\convert> 