### PR TITLE
Add a landing page to prevent loading 180+ MB as soon as page is loaded.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,52 +1,89 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-  <link rel="stylesheet" href="style.css">
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <title>Convert to it!</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      font-family: sans-serif;
+      background: linear-gradient(#1C77FF 0 30vh, lightgray 30vh 100%);
+      color: #000000;
+    }
+
+    main {
+      text-align: center;
+      padding: 28px;
+      border-radius: 12px;
+      background: rgb(184, 184, 184);
+      width: min(520px, 88vw);
+    }
+
+    h1 {
+      color: #ffffff;
+      margin-top: 10px;
+      margin-bottom: 8px;
+    }
+
+    .icon {
+      width: 40px;
+      height: 40px;
+    }
+
+    a {
+      display: inline-block;
+      margin-top: 16px;
+      padding: 12px 20px;
+      border-radius: 10px;
+      text-decoration: none;
+      background: #1C77FF;
+      color: #ffffff;
+      font-weight: 700;
+      box-shadow: 0 5px 0 0 rgba(169, 169, 169, 0.4);
+    }
+
+    .actions {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      align-items: center;
+      flex-wrap: wrap;
+      margin-top: 16px;
+    }
+
+    .actions a {
+      margin-top: 0;
+    }
+
+    .repo-link {
+      padding: 9px 14px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      background: #ffffff;
+      color: #1C77FF;
+    }
+  </style>
 </head>
+
 <body>
-
-  <input id="file-input" type="file">
-
-  <div id="file-area">
-    <h2>Click to add your file</h2>
-    <p id="drop-hint-text">or drag and drop it here</p>
-  </div>
-  <div id="side-panel">
-    <button id="mode-button">Advanced mode</button>
-  </div>
-
-  <div id="format-containers">
-
-    <div id="from-container" class="format-container">
-      <h2>Convert from:</h2>
-      <input type="text" id="search-from" class="search" placeholder="Search">
-      <div id="from-list" class="format-list">
-
-      </div>
+  <main>
+    <img class="icon" src="favicon.ico" alt="Convert to it icon">
+    <h1>Convert to it!</h1>
+    <p>Runs in your browser. Files stay local.</p>
+    <p>Pick an input format and an output format, then run conversion.</p>
+    <p>If no direct path exists, intermediate formats are used.</p>
+    <p>Open Source.</p>
+    <div class="actions">
+      <a href="/convert/start/">Open converter</a>
+      <a class="repo-link" href="https://github.com/p2r3/convert/" target="_blank" rel="noopener noreferrer">Repo on GitHub</a>
     </div>
-
-    <div id="to-container" class="format-container">
-      <h2>Convert to:</h2>
-      <input type="text" id="search-to" class="search" placeholder="Search">
-      <div id="to-list" class="format-list">
-
-      </div>
-    </div>
-
-  </div>
-
-  <button id="convert-button" class="disabled">Convert</button>
-
-  <div id="popup-bg"></div>
-  <div id="popup">
-    <h2>Loading tools...</h2>
-  </div>
-
-  <script type="module" src="src/main.ts"></script>
-
+  </main>
 </body>
+
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,11 @@ const ui = {
   popupBackground: document.querySelector("#popup-bg") as HTMLDivElement
 };
 
+const setConvertEnabled = (enabled: boolean) => {
+  ui.convertButton.disabled = !enabled;
+  ui.convertButton.className = enabled ? "" : "disabled";
+};
+
 /**
  * Filters a list of butttons to exclude those not matching a substring.
  * @param list Button list (div) to filter.
@@ -193,6 +198,7 @@ async function buildOptionList () {
   allOptions.length = 0;
   ui.inputList.innerHTML = "";
   ui.outputList.innerHTML = "";
+  setConvertEnabled(false);
 
   for (const handler of handlers) {
     if (!window.supportedFormatCache.has(handler.name)) {
@@ -254,11 +260,7 @@ async function buildOptionList () {
         if (previous) previous.className = "";
         event.target.className = "selected";
         const allSelected = document.getElementsByClassName("selected");
-        if (allSelected.length === 2) {
-          ui.convertButton.className = "";
-        } else {
-          ui.convertButton.className = "disabled";
-        }
+        setConvertEnabled(allSelected.length === 2);
       };
 
       if (format.from && addToInputs) {

--- a/start/index.html
+++ b/start/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+  <title>Convert to it!</title>
+</head>
+<body>
+
+  <input id="file-input" type="file">
+
+  <div id="file-area">
+    <h2>Click to add your file</h2>
+    <p id="drop-hint-text">or drag and drop it here</p>
+  </div>
+  <div id="side-panel">
+    <button id="mode-button">Advanced mode</button>
+  </div>
+
+  <div id="format-containers">
+
+    <div id="from-container" class="format-container">
+      <h2>Convert from:</h2>
+      <input type="text" id="search-from" class="search" placeholder="Search">
+      <div id="from-list" class="format-list">
+
+      </div>
+    </div>
+
+    <div id="to-container" class="format-container">
+      <h2>Convert to:</h2>
+      <input type="text" id="search-to" class="search" placeholder="Search">
+      <div id="to-list" class="format-list">
+
+      </div>
+    </div>
+
+  </div>
+
+  <button id="convert-button" class="disabled" disabled>Convert</button>
+
+  <div id="popup-bg"></div>
+  <div id="popup">
+    <h2>Loading tools...</h2>
+  </div>
+
+  <script type="module" src="/src/main.ts"></script>
+
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -137,6 +137,11 @@ button.selected {
   pointer-events: none;
 }
 
+#convert-button:disabled {
+  filter: grayscale(1);
+  cursor: not-allowed;
+}
+
 #popup-bg {
   position: fixed;
   left: 0;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,17 @@
 import { defineConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { resolve } from "node:path";
 
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: {
+        landing: resolve(__dirname, "index.html"),
+        start: resolve(__dirname, "start/index.html"),
+      }
+    }
+  },
   optimizeDeps: {
     exclude: [
       "@ffmpeg/ffmpeg",


### PR DESCRIPTION
# Previously using tons of bandwidth:
<img width="402" height="34" alt="image" src="https://github.com/user-attachments/assets/9e20d378-fa3e-4452-9c5d-39a8f9541d37" />

Now it will have a very simple landing page and link to the repo.

(Good at least before we get the UI upgrade)

# Preview
<img width="1920" height="1092" alt="image" src="https://github.com/user-attachments/assets/2e0603fa-f50e-4204-ad61-d2c69bfa1d56" />
