### PR TITLE
Fixes to audio > image > audio pipeline in meyda.ts

### DIFF
--- a/src/handlers/meyda.ts
+++ b/src/handlers/meyda.ts
@@ -148,12 +148,6 @@ class meydaHandler implements FormatHandler {
         const sampleRate = this.#audioContext.sampleRate;
 
         const audioData = new Float32Array(imageWidth * hopSize + bufferSize);
-        const window = new Float32Array(bufferSize);
-
-        // Generate Hanning window
-        for (let i = 0; i < bufferSize; i++) {
-          window[i] = 0.5 * (1 - Math.cos(2 * Math.PI * i / bufferSize));
-        }
 
         // Precompute sine and cosine waves for each frequency
         const sineWaves = new Float32Array(imageHeight * bufferSize);
@@ -188,10 +182,10 @@ class meydaHandler implements FormatHandler {
             }
           }
 
-          // Apply window and overlap-add
+          // overlap-add
           const outputOffset = x * hopSize;
           for (let s = 0; s < bufferSize; s ++) {
-            audioData[outputOffset + s] += frameData[s] * window[s];
+            audioData[outputOffset + s] += frameData[s];
           }
         }
 
@@ -244,7 +238,8 @@ class meydaHandler implements FormatHandler {
 
           const pixels = new Uint8ClampedArray(imageHeight * 4);
           for (let j = 0; j < imageHeight; j ++) {
-            const magnitude = Math.sqrt(real[j] * real[j] + imaginary[j] * imaginary[j]);
+            // Calculate amplitude, amplitude is halved when only half of the FFT is used, so double it
+            const magnitude = Math.sqrt(real[j] * real[j] + imaginary[j] * imaginary[j]) / bufferSize * 2;
             const phase = Math.atan2(imaginary[j], real[j]);
             const pixelIndex = (imageHeight - j - 1) * 4;
             // Encode magnitude in R, G channels


### PR DESCRIPTION
Correct the amplitude calculation for audio > image by dividing result by bufferSize, and remove the windowing function in image > audio. 


Image before:
<img width="2048" height="1024" alt="ChaozFantasy" src="https://github.com/user-attachments/assets/71f48cd6-5373-46d8-ba30-0d2b2e31a5d0" />

Image after:
<img width="2048" height="1024" alt="ChaozFantasy(1)" src="https://github.com/user-attachments/assets/bdfa9bdc-18e8-4b12-a5fa-488ac11be5d2" />
don't worry about the second image having little green, you could normalize based on the maximum amplitude if you prefer that method, i think this sounds fine

There's still some issues, there seems to be a cap at 15khz, and some stray green pixels show up that you can hear when converting back to audio, not sure about that.
