### PR TITLE
Fix height of svg when converting from html

### DIFF
--- a/src/handlers/svgForeignObject.ts
+++ b/src/handlers/svgForeignObject.ts
@@ -42,10 +42,9 @@ class svgForeignObjectHandler implements FormatHandler {
     document.body.appendChild(dummy);
 
     // Add a DOM shadow to the dummy to "sterilize" it.
-    // We also clear all styles within the shadow to be doubly sure.
     const shadow = dummy.attachShadow({ mode: "closed" });
     const style = document.createElement("style");
-    style.textContent = "*{all:initial;box-sizing:border-box;}";
+    style.textContent = ":host>div{display:flow-root;}";
     shadow.appendChild(style);
 
     // Create a div within the shadow DOM to act as
@@ -56,9 +55,10 @@ class svgForeignObjectHandler implements FormatHandler {
 
     // Wait for all images to finish loading. This is required for layout
     // changes, not because we actually care about the image contents.
-    const images = container.querySelectorAll("img");
+    const images = container.querySelectorAll("img, video");
     const promises = Array.from(images).map(image => new Promise(resolve => {
       image.addEventListener("load", resolve);
+      image.addEventListener("loadeddata", resolve);
       image.addEventListener("error", resolve);
     }));
     await Promise.all(promises);
@@ -101,11 +101,11 @@ class svgForeignObjectHandler implements FormatHandler {
       const html = decoder.decode(bytes);
       const { xml, bbox } = await svgForeignObjectHandler.normalizeHTML(html);
       const svg = (
-`<svg width="${bbox.width}" height="${bbox.height * 1.5}" xmlns="http://www.w3.org/2000/svg">
-<foreignObject x="0" y="0" width="${bbox.width}" height="${bbox.height * 1.5}">
-${xml}
-</foreignObject>
-</svg>`);
+        `<svg width="${bbox.width}" height="${bbox.height}" xmlns="http://www.w3.org/2000/svg">
+        <foreignObject x="0" y="0" width="${bbox.width}" height="${bbox.height}">
+        ${xml}
+        </foreignObject>
+        </svg>`);
       const outputBytes = encoder.encode(svg);
       const newName = (name.endsWith(".html") ? name.slice(0, -5) : name) + ".svg";
       outputFiles.push({ name: newName, bytes: outputBytes });


### PR DESCRIPTION
Fixes #74 
Fixes #142 

The height of the SVG is now calculated correctly by not resetting all the styles. And it waits for video's to load.