### PR TITLE
docker: change nginx base to stable-alpine

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN bun run build
 RUN bun run buildCache.js dist/cache.json
 
-FROM nginx:1.27-alpine AS runtime
+FROM nginx:stable-alpine AS runtime
 
 COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html/convert


### PR DESCRIPTION
I noticed that I accidentally used an old version of nginx while creating the docker file due to me copying that section from an old deployment of mine. This old tag was out of support for the last 10 months. Sorry about that.

I have changed it so that it now uses the most recent stable version of nginx. The nginx config is basic enough that this shouldnt ever really be an issue.

If absolute stability is desired we can lock it down to 1.28 and manually update it when nginx does, but I think that would be overkill.


**I tested this updated version on my own deployment server and it appears to have no issues.**
(Verified by building from source locally and spinning up the container with the `convert:dev` tag as per docker-compose.override.yml)