### PR TITLE
Create pull_request_template.md for PR submissions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Type of change
+<!-- Mark the relevant option with an "x" -->
+- [ ] Feature
+- [ ] Bugfix
+- [ ] File Format
+
+## Pull request summary
+<!-- Summarise what your PR does -->
+
+
+## Changes Made
+<!-- List the specific changes you've made -->
+- 
+- 
+- 
+
+## Related Issues
+<!-- Link any related issues here -->
+Fixes #(issue number)
+
+
+## Basic checklist
+<!-- Mark completed items with an "x" -->
+- [ ] PR is functional and follows good practices
+- [ ] I've read and followed contributing guidance in [README.md](README.md)
+- [ ] I have performed a self-review of my own code
+- [ ] Complex code is documented
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings or errors
+- [ ] I have tested my changes thoroughly
+- [ ] Any dependent changes have been merged and published
+
+## Longer description / Additional comments
+<!-- Add additional details here, only if required -->


### PR DESCRIPTION
Simple change to add a pull request template for contributors to follow.
Just a basic template for now
Can be additionally edited as seen fit once merged.