### PR TITLE
Add plugin registration API for custom handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ The best way to contribute is by adding support for new file formats (duh). Here
 
 ### Creating a handler
 
-Each "tool" used for conversion has to be normalized to a standard form - effectively a "wrapper" that abstracts away the internal processes. These wrappers are available in [src/handlers](src/handlers/).
+Each "tool" used for conversion has to be normalized to a standard form - effectively a "wrapper" that abstracts away the internal processes. 
+
+The recommended way to add a handler is by creating a file in [src/plugins/](src/plugins/). Any file in this directory that uses `export default` for its handler class will be automatically discovered and registered at build time. This allows you to add new formats without modifying any core files. Core handlers are located in [src/handlers](src/handlers/).
 
 Below is a super barebones handler that does absolutely nothing. You can use this as a starting point for adding a new format:
 
@@ -138,7 +140,7 @@ There are a few additional things that I want to point out in particular:
 If your tool requires an external dependency (which it likely does), there are currently two well-established ways of going about this:
 
 - If it's an `npm` package, just install it to the project like you normally would.
-- If it's a Git repository, add it as a submodule to [src/handlers](src/handlers).
+- If it's a Git repository, add it as a submodule to [src/plugins](src/plugins) or [src/handlers](src/handlers).
 
 **Please try to avoid CDNs (Content Delivery Networks).** They're really cool on paper, but they don't work well with TypeScript, and each one introduces a tiny bit of instability. For a project that leans heavily on external dependencies, those bits of instability can add up fast.
 

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -48,4 +48,18 @@ try { handlers.push(new peToZipHandler()) } catch (_) { };
 try { handlers.push(new flptojsonHandler()) } catch (_) { };
 try { handlers.push(new floHandler()) } catch (_) { };
 
+// Load plugins from ../plugins directory
+const plugins = import.meta.glob('../plugins/*.ts', { eager: true });
+
+for (const path in plugins) {
+    try {
+        const module = plugins[path] as { default: new () => FormatHandler };
+        if (module.default) {
+            handlers.push(new module.default());
+        }
+    } catch (e) {
+        console.error(`Failed to load plugin at ${path}:`, e);
+    }
+}
+
 export default handlers;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import type { FileFormat, FileData, FormatHandler, ConvertPathNode } from "./FormatHandler.js";
 import normalizeMimeType from "./normalizeMimeType.js";
 import handlers from "./handlers";
+import "./pluginRegistry.ts";
 
 /** Files currently selected for conversion */
 let selectedFiles: File[] = [];
@@ -14,10 +15,10 @@ let simpleMode: boolean = true;
 
 /** Handlers that support conversion from any formats. */
 const conversionsFromAnyInput: ConvertPathNode[] = handlers
-.filter(h => h.supportAnyInput && h.supportedFormats)
-.flatMap(h => h.supportedFormats!
-  .filter(f => f.to)
-  .map(f => ({ handler: h, format: f})))
+  .filter(h => h.supportAnyInput && h.supportedFormats)
+  .flatMap(h => h.supportedFormats!
+    .filter(f => f.to)
+    .map(f => ({ handler: h, format: f })))
 
 const ui = {
   fileInput: document.querySelector("#file-input") as HTMLInputElement,
@@ -188,7 +189,7 @@ window.printSupportedFormatCache = () => {
   return JSON.stringify(entries, null, 2);
 }
 
-async function buildOptionList () {
+async function buildOptionList() {
 
   allOptions.length = 0;
   ui.inputList.innerHTML = "";
@@ -314,7 +315,7 @@ const convertPathCache: Array<{
   node: ConvertPathNode
 }> = [];
 
-async function attemptConvertPath (files: FileData[], path: ConvertPathNode[]) {
+async function attemptConvertPath(files: FileData[], path: ConvertPathNode[]) {
 
   ui.popupBox.innerHTML = `<h2>Finding conversion route...</h2>
     <p>Trying <b>${path.map(c => c.format.format).join(" → ")}</b>...</p>`;
@@ -323,7 +324,7 @@ async function attemptConvertPath (files: FileData[], path: ConvertPathNode[]) {
   if (cacheLast) files = cacheLast.files;
 
   const start = cacheLast ? convertPathCache.length : 0;
-  for (let i = start; i < path.length - 1; i ++) {
+  for (let i = start; i < path.length - 1; i++) {
     const handler = path[i + 1].handler;
     try {
       let supportedFormats = window.supportedFormatCache.get(handler.name);
@@ -352,7 +353,7 @@ async function attemptConvertPath (files: FileData[], path: ConvertPathNode[]) {
 
 }
 
-async function buildConvertPath (
+async function buildConvertPath(
   files: FileData[],
   target: ConvertPathNode,
   queue: ConvertPathNode[][]
@@ -367,7 +368,7 @@ async function buildConvertPath (
     if (!path) continue;
     if (path.length > 5) continue;
 
-    for (let i = 1; i < path.length; i ++) {
+    for (let i = 1; i < path.length; i++) {
       if (path[i] !== convertPathCache[i]?.node) {
         convertPathCache.length = i - 1;
         break;
@@ -409,7 +410,7 @@ async function buildConvertPath (
 
       for (const conversion of anyConversions) {
         const attempt = await attemptConvertPath(files, path.concat(conversion));
-        if (attempt) return attempt; 
+        if (attempt) return attempt;
       }
 
       isNestedConversion = true;
@@ -432,7 +433,7 @@ async function buildConvertPath (
 
 }
 
-function downloadFile (bytes: Uint8Array, name: string, mime: string) {
+function downloadFile(bytes: Uint8Array, name: string, mime: string) {
   const blob = new Blob([bytes as BlobPart], { type: mime });
   const link = document.createElement("a");
   link.href = URL.createObjectURL(blob);

--- a/src/pluginRegistry.ts
+++ b/src/pluginRegistry.ts
@@ -1,0 +1,27 @@
+import type { FormatHandler } from "./FormatHandler.ts";
+import handlers from "./handlers/index.ts";
+
+declare global {
+    interface Window {
+        registerPlugin: (handler: FormatHandler) => void;
+    }
+}
+
+/**
+ * Registers a new format handler at runtime.
+ * Useful for debugging or external scripts.
+ * @param handler The handler instance to register.
+ */
+export function registerPlugin(handler: FormatHandler) {
+    handlers.push(handler);
+    // Clear the cache for this handler so it gets re-initialized if needed
+    if (window.supportedFormatCache) {
+        window.supportedFormatCache.delete(handler.name);
+    }
+    console.log(`Plugin "${handler.name}" registered successfully.`);
+}
+
+// Expose to window for console access
+if (typeof window !== "undefined") {
+    window.registerPlugin = registerPlugin;
+}

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -1,0 +1,24 @@
+# Plugins
+
+This directory contains custom file format handlers. Any file in this directory that exports a class implementing `FormatHandler` as its **default export** will be automatically loaded by the application.
+
+## How to add a plugin
+
+1. Create a new `.ts` file in this directory (e.g., `my-format.ts`).
+2. Copy the structure from `example.ts` or any core handler in `../handlers/`.
+3. Implement the `FormatHandler` interface.
+4. Ensure you `export default` your class.
+
+## Example
+
+```typescript
+import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
+
+class MyHandler implements FormatHandler {
+  // ... implementation ...
+}
+
+export default MyHandler;
+```
+
+**Note:** You do not need to register your plugin anywhere else. The build system will find it automatically.

--- a/src/plugins/example.ts
+++ b/src/plugins/example.ts
@@ -1,0 +1,58 @@
+
+import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
+
+/**
+ * An example plugin that reverses the content of text files.
+ * This demonstrates how to implement the FormatHandler interface.
+ */
+class ReverseTextHandler implements FormatHandler {
+
+    public name: string = "Reverse Text (Plugin Example)";
+    public supportedFormats?: FileFormat[];
+    public ready: boolean = false;
+
+    async init() {
+        this.supportedFormats = [
+            {
+                name: "Text File (Reversed)",
+                format: "txt-rev",
+                extension: "txt",
+                mime: "text/plain",
+                from: false, // We don't support converting FROM this specific "format" in this example
+                to: true,    // We support converting TO this format (by reversing input)
+                internal: "txt-rev"
+            },
+        ];
+        this.ready = true;
+    }
+
+    async doConvert(
+        inputFiles: FileData[],
+        inputFormat: FileFormat,
+        outputFormat: FileFormat
+    ): Promise<FileData[]> {
+        const outputFiles: FileData[] = [];
+
+        for (const file of inputFiles) {
+            // Decode bytes to string
+            const text = new TextDecoder().decode(file.bytes);
+
+            // Reverse the string
+            const reversed = text.split("").reverse().join("");
+
+            // Encode back to bytes
+            const bytes = new TextEncoder().encode(reversed);
+
+            outputFiles.push({
+                name: `reversed_${file.name}`,
+                bytes: bytes
+            });
+        }
+
+        return outputFiles;
+    }
+
+}
+
+// Default export is required for automatic discovery!
+export default ReverseTextHandler;


### PR DESCRIPTION
This PR adds a plugin registration API so you can add custom handlers without forking the repo (not a perfect hook, but zero-touch for core files)

Note that you can just drop files into src/plugins/ and they'll get picked up automatically at build time

This allows adding new formats without touching src/handlers/index.ts every single time :)