### PR TITLE
fix action: missing npmrc in docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
+COPY .npmrc ./
 COPY package.json ./
-RUN bun install
+RUN bun install --frozen-lockfile
 
 COPY . .
 


### PR DESCRIPTION
#197 introduced a .npmrc to add support for custom npm sources. That broke the docker build due to the file not being copied into the container. This PR corrects this behavior while also adding frozen-lockfile to ensure it behaves the same as the pages action.

Tested locally using the `convert:dev` tag

Action ran [successfully in my fork repository](https://github.com/PoliceFighter761/convert/actions/runs/22106634423/job/63891137231)