### PR TITLE
fix(pyTurtle): use the right mimetype for python programs

### DIFF
--- a/src/handlers/pyTurtle.ts
+++ b/src/handlers/pyTurtle.ts
@@ -37,7 +37,7 @@ class pyTurtleHandler implements FormatHandler {
         name: "Python Turtle program",
         format: "py",
         extension: "py",
-        mime: "text/plain",
+        mime: "text/x-python",
         from: false,
         to: true,
         internal: "pyTurtle"


### PR DESCRIPTION
This PR fixes #188 by using python mimetype instead of text mimetype, to not collide with #186. 

otherwise, you get this strange case where user would choose `pyTurtle` as output and get instead the TXT output for some reason