### PR TITLE
Text to BAT and SH scripts

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -26,6 +26,8 @@ import flptojsonHandler from "./flptojson.ts";
 import floHandler from "./flo.ts";
 import batToExeHandler from "./batToExe.ts";
 import textEncodingHandler from "./textEncoding.ts";
+import textToSHHandler from "./textToSH.ts";
+import textToBatHandler from "./textToBat.ts";
 
 const handlers: FormatHandler[] = [];
 try { handlers.push(new svgTraceHandler()) } catch (_) { };
@@ -56,5 +58,7 @@ try { handlers.push(new flptojsonHandler()) } catch (_) { };
 try { handlers.push(new floHandler()) } catch (_) { };
 try { handlers.push(new batToExeHandler()) } catch (_) { };
 try { handlers.push(new textEncodingHandler()) } catch (_) { };
+try { handlers.push(new textToSHHandler()) } catch (_) { };
+try { handlers.push(new textToBatHandler()) } catch (_) { };
 
 export default handlers;

--- a/src/handlers/textToBat.ts
+++ b/src/handlers/textToBat.ts
@@ -1,0 +1,66 @@
+import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
+
+class textToBatHandler implements FormatHandler {
+
+  public name: string = "textToBat";
+
+  public supportedFormats: FileFormat[] = [
+    {
+      name: "Plain Text",
+      format: "text",
+      extension: "txt",
+      mime: "text/plain",
+      from: true,
+      to: false,
+      internal: "text"
+    },
+    {
+      name: "Windows Batch file",
+      format: "batch",
+      extension: "text/bat",
+      mime: "text/windows-batch",
+      from: false,
+      to: true,
+      internal: "bat"
+    },
+  ];
+
+  public supportAnyInput: boolean = false;
+
+  public ready: boolean = false;
+
+  async init() {
+    this.ready = true;
+  }
+
+  async doConvert(
+    inputFiles: FileData[],
+    inputFormat: FileFormat,
+    outputFormat: FileFormat
+  ): Promise<FileData[]> {
+
+    const outputFiles: FileData[] = [];
+
+    for (const file of inputFiles) {
+      const dec = new TextDecoder("utf-8");
+      let text = dec.decode(file.bytes)
+        // Escape special characters
+        .replaceAll("%","%%")
+        .replaceAll(/[&><^()|"]/g, function (x) { return `^${x}`; })
+        // New lines
+        .replaceAll("\n","\nECHO.");
+
+      let newText = `@ECHO OFF\nECHO ${text}`;
+
+      const utf8Bytes = new TextEncoder().encode(newText);
+
+      const name = file.name.split(".")[0] + "." + "bat";
+
+      outputFiles.push({bytes: utf8Bytes, name: name})
+    }
+
+    return outputFiles;
+  }
+}
+
+export default textToBatHandler;

--- a/src/handlers/textToSH.ts
+++ b/src/handlers/textToSH.ts
@@ -1,0 +1,61 @@
+import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
+
+class textToSHHandler implements FormatHandler {
+
+  public name: string = "textToSH";
+
+  public supportedFormats: FileFormat[] = [
+    {
+      name: "Plain Text",
+      format: "text",
+      extension: "txt",
+      mime: "text/plain",
+      from: true,
+      to: false,
+      internal: "text"
+    },
+    {
+      name: "Shell Script",
+      format: "sh",
+      extension: "sh",
+      mime: "application/x-sh",
+      from: false,
+      to: true,
+      internal: "sh"
+    }
+  ];
+
+  public supportAnyInput: boolean = false;
+
+  public ready: boolean = false;
+
+  async init() {
+    this.ready = true;
+  }
+
+  async doConvert(
+    inputFiles: FileData[],
+    inputFormat: FileFormat,
+    outputFormat: FileFormat
+  ): Promise<FileData[]> {
+
+    const outputFiles: FileData[] = [];
+
+    for (const file of inputFiles) {
+      const dec = new TextDecoder("utf-8");
+      let text = dec.decode(file.bytes).replaceAll("\"", "\\\"");
+
+      let newText = `#!/bin/sh\necho "${text}"`;
+
+      const utf8Bytes = new TextEncoder().encode(newText);
+
+      const name = file.name.split(".")[0] + "." + outputFormat.extension;
+
+      outputFiles.push({bytes: utf8Bytes, name: name})
+    }
+
+    return outputFiles;
+  }
+}
+
+export default textToSHHandler;


### PR DESCRIPTION
Adds converters for text to SH (Linux script) and text to BAT (Windows script)

These are fairly straightforward, they just print the content. The BAT converter is more complex since it has to escape special characters.

The fun part is the connections this opens up. For example:
<img width="868" height="830" alt="image" src="https://github.com/user-attachments/assets/37c45460-8d50-4618-973e-a401f874d3ca" />

And the BAT (testing through wine):
<img width="864" height="839" alt="image" src="https://github.com/user-attachments/assets/9d9bf995-f538-41b8-9225-9a0cab5b7349" />
