### PR TITLE
Add Beat Saber Open Replay

### DIFF
--- a/src/handlers/bsor.ts
+++ b/src/handlers/bsor.ts
@@ -1,0 +1,67 @@
+import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
+import { Replay } from "./bsor/replay.ts";
+import { render } from "./bsor/renderer.ts";
+import CommonFormats from "src/CommonFormats.ts";
+
+class bsorHandler implements FormatHandler {
+  public name: string = "bsor";
+  public supportedFormats: FileFormat[] = [
+    {
+      name: "Beat Saber Open Replay",
+      format: "bsor",
+      extension: "bsor",
+      mime: "application/x-bsor",
+      from: true,
+      to: false,
+      internal: "bsor"
+    },
+    CommonFormats.PNG.supported("png", false, true),
+    CommonFormats.JPEG.supported("jpeg", false, true),
+    CommonFormats.JSON.supported("json", false, true, true)
+  ];
+
+  public ready: boolean = true;
+
+  async init() {
+    this.ready = true;
+  }
+
+  async doConvert (
+    inputFiles: FileData[],
+    inputFormat: FileFormat,
+    outputFormat: FileFormat
+  ): Promise<FileData[]> {
+    let frameIndex = 0;
+    return (await Promise.all(inputFiles.map(async(file) => {
+      const replay = new Replay(file.bytes);
+      if(outputFormat.internal == "json") {
+        return [{
+          name: file.name.split(".")[0] + ".json",
+          bytes: new TextEncoder().encode(JSON.stringify(replay))
+        }];
+      }
+      let outputs: FileData[] = [];
+      await new Promise<void>(resolve => {
+        render(replay, 640, 480,
+          async(renderer) => {
+            const bytes: Uint8Array = await new Promise((resolve, reject) => {
+              renderer.domElement.toBlob((blob) => {
+                if (!blob) return reject("Canvas output failed");
+                blob.arrayBuffer().then(buf => resolve(new Uint8Array(buf)));
+              }, outputFormat.mime);
+            });
+            outputs.push({
+              name: file.name.split(".")[0]+"_"+(frameIndex++)+"."+outputFormat.extension,
+              bytes: bytes
+            });
+          },
+          async() => resolve()
+        );
+      })
+      return outputs;
+    }))).flat();
+  }
+
+}
+
+export default bsorHandler;

--- a/src/handlers/bsor/renderer.ts
+++ b/src/handlers/bsor/renderer.ts
@@ -1,0 +1,168 @@
+import * as THREE from "three";
+import { Vector3, Quaternion, Mesh } from "three";
+
+import * as BSOR from "./replay.ts";
+
+export async function render(replay: BSOR.Replay, width: number, height: number, onFrame: (renderer: THREE.WebGLRenderer) => Promise<void>, onDone: () => Promise<void>) {
+	const scene = new THREE.Scene();
+	const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+
+	const renderer = new THREE.WebGLRenderer();
+	renderer.setSize(width, height);
+
+	const frames = [...replay.frames].sort((a, b) => a.time - b.time);
+	let frameIndex = 0;
+	const noteEvents = [...replay.notes].sort((a, b) => a.time - b.time);
+	let noteIndex = 0;
+	const leftMaterial = new THREE.MeshBasicMaterial({ color: 0xFF0000 });
+	const rightMaterial = new THREE.MeshBasicMaterial({ color: 0x0080FF });
+	const saberGeometry = new THREE.BoxGeometry(0.05, 1.25, 0.05).translate(0, 0.6, 0);
+	class Saber {
+		mesh: Mesh;
+
+		constructor(material: THREE.Material) {
+			this.mesh = new Mesh(saberGeometry, material)
+			scene.add(this.mesh);
+		}
+
+		update(position: Vector3, rotation: Quaternion) {
+			this.mesh.position.set(position.x, position.y, -position.z);
+			this.mesh.quaternion.set(rotation.x, rotation.y, rotation.z, rotation.w);
+			this.mesh.rotateX(Math.PI/2);
+		}
+	}
+	const sabers = [
+		new Saber(leftMaterial),
+		new Saber(rightMaterial)
+	];
+	const TIME_SCALE = 20;
+	const REACTION_TIME = 1;
+	const NOTE_SCALE = 0.8;
+	const ARROW_SIZE = NOTE_SCALE*0.75;
+	const arrowGeometry = new THREE.BufferGeometry();
+	arrowGeometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array([
+		-ARROW_SIZE/2, 0, NOTE_SCALE*0.55,
+		ARROW_SIZE/2, 0, NOTE_SCALE*0.55,
+		0, NOTE_SCALE*0.4, NOTE_SCALE*0.55,
+	]), 3));
+	const arrowMaterial = new THREE.MeshBasicMaterial({ color: 0xFFFFFF });
+	const noteGeometry = new THREE.BoxGeometry(NOTE_SCALE, NOTE_SCALE, NOTE_SCALE);
+	const dotGeometry = new THREE.CircleGeometry(NOTE_SCALE*0.25).translate(0, 0, NOTE_SCALE*0.55);
+	const bombGeometry = new THREE.SphereGeometry(NOTE_SCALE);
+	const bombMaterial = new THREE.MeshBasicMaterial({ color: 0x808080 });
+	class Note {
+		data: BSOR.Note;
+		bloq: THREE.Mesh;
+		arrow: THREE.Mesh;
+		removalQueued: boolean;
+
+		constructor(data: BSOR.Note) {
+			if(data.type == BSOR.CutType.BOMB) {
+				this.bloq = new Mesh(bombGeometry, bombMaterial);
+			}
+			else {
+				this.bloq = new Mesh(noteGeometry, data.color == BSOR.NoteColor.LEFT ? leftMaterial : rightMaterial);
+			}
+			if(data.cutDirection == BSOR.CutDirection.ANY) {
+				this.arrow = new Mesh(dotGeometry, arrowMaterial);
+			}
+			else {
+				this.arrow = new Mesh(arrowGeometry, arrowMaterial);
+				this.arrow.position.set(0, -NOTE_SCALE*0.4, 0);
+			}
+			this.bloq.add(this.arrow);
+			switch(data.cutDirection) {
+				case BSOR.CutDirection.UP:
+					break;
+				case BSOR.CutDirection.DOWN:
+					this.bloq.rotateZ(Math.PI);
+					break;
+				case BSOR.CutDirection.LEFT:
+					this.bloq.rotateZ(Math.PI/2);
+					break;
+				case BSOR.CutDirection.RIGHT:
+					this.bloq.rotateZ(-Math.PI/2);
+					break;
+				case BSOR.CutDirection.UP_LEFT:
+					this.bloq.rotateZ(Math.PI*0.25);
+					break;
+				case BSOR.CutDirection.UP_RIGHT:
+					this.bloq.rotateZ(-Math.PI*0.25);
+					break;
+				case BSOR.CutDirection.DOWN_LEFT:
+					this.bloq.rotateZ(Math.PI*0.75);
+					break;
+				case BSOR.CutDirection.DOWN_RIGHT:
+					this.bloq.rotateZ(-Math.PI*0.75);
+					break;
+				case BSOR.CutDirection.ANY:
+					break;
+				case BSOR.CutDirection.NONE:
+					break;
+
+			}
+			this.data = data;
+			this.removalQueued = false;
+			scene.add(this.bloq);
+		}
+		update(time: number) {
+			this.bloq.position.set(this.data.lineIndex-1.5, this.data.lineLayer, TIME_SCALE*(time-this.data.spawnTime));
+			this.removalQueued = this.shouldRemove(time);
+			if(this.removalQueued) {
+				scene.remove(this.bloq);
+			}
+		}
+		shouldRemove(time: number): boolean {
+			if(this.data.type != BSOR.CutType.MISS) {
+				return time >= this.data.time;
+			}
+			return this.data.spawnTime >= time-REACTION_TIME;
+		}
+
+	}
+	let notes: Note[] = [];
+
+	camera.position.z = 2;
+	camera.position.y = 1.5;
+
+  let time = 0;
+
+  while(true) {
+    time += 1/30;
+		while(frameIndex < frames.length && frames[frameIndex].time <= time) {
+			const frame = frames[frameIndex];
+			frameIndex++;
+      sabers[0].update(frame.leftHand.position, frame.leftHand.rotation);
+      sabers[1].update(frame.rightHand.position, frame.rightHand.rotation);
+		}
+		while(noteIndex < noteEvents.length && noteEvents[noteIndex].time <= time+REACTION_TIME) {
+			const note = noteEvents[noteIndex];
+			notes.push(new Note(note));
+			noteIndex++;
+		}
+		for(const note of notes) {
+			note.update(time);
+		}
+		notes = notes.filter(n => !n.removalQueued);
+
+		renderer.render(scene, camera);
+		await onFrame(renderer);
+
+		if(frameIndex >= frames.length) {
+			// cleanup
+			leftMaterial.dispose();
+			rightMaterial.dispose();
+			saberGeometry.dispose();
+			arrowGeometry.dispose();
+			arrowMaterial.dispose();
+			noteGeometry.dispose();
+			dotGeometry.dispose();
+			bombGeometry.dispose();
+			bombMaterial.dispose();
+			// stop animation
+			await onDone();
+      break;
+		}
+	}
+	// TODO: walls
+}

--- a/src/handlers/bsor/replay.ts
+++ b/src/handlers/bsor/replay.ts
@@ -1,0 +1,417 @@
+import { Vector3, Quaternion } from "three";
+
+// See BSOR specification for more info:
+// https://github.com/BeatLeader/BS-Open-Replay
+
+export interface Frame {
+	time: number;
+	fps: number;
+	head: {
+		position: Vector3,
+		rotation: Quaternion
+	};
+	leftHand: {
+		position: Vector3,
+		rotation: Quaternion
+	};
+	rightHand: {
+		position: Vector3,
+		rotation: Quaternion
+	};
+}
+
+export enum ScoringType {
+	NORMAL = 0,
+	IGNORE,
+	NO_SCORE,
+	NORMAL2 = 3, // ???
+	SLIDER_HEAD,
+	SLIDER_TAIL,
+	BURST_SLIDER_HEAD,
+	BURST_SLIDER_ELEMENT
+}
+
+export enum Saber {
+	LEFT = 0,
+	RIGHT = 1
+}
+
+export enum CutType {
+	GOOD = 0,
+	BAD,
+	MISS,
+	BOMB
+}
+
+export enum NoteColor {
+	LEFT = 0,
+	RIGHT = 1
+}
+
+export enum CutDirection {
+	UP = 0,
+	DOWN,
+	LEFT,
+	RIGHT,
+	UP_LEFT,
+	UP_RIGHT,
+	DOWN_LEFT,
+	DOWN_RIGHT,
+	ANY,
+	NONE
+}
+
+export interface NoteBase {
+	scoringType: ScoringType;
+	lineIndex: number;
+	lineLayer: number;
+	color: NoteColor;
+	cutDirection: CutDirection;
+	time: number;
+	spawnTime: number;
+}
+export interface CutInfo {
+	ok: {
+		speed: boolean,
+		direction: boolean,
+		saberType: boolean
+	};
+	wasCutTooSoon: boolean;
+	saber: {
+		speed: number,
+		dir: Vector3,
+		type: Saber
+	};
+	cut: {
+		timeDeviation: number,
+		dirDeviation: number,
+		point: Vector3,
+		normal: Vector3,
+		distanceToCenter: number,
+		angle: number,
+		beforeCutRating: number,
+		afterCutRating: number
+	};
+}
+export interface GoodCut extends NoteBase {
+	type: CutType.GOOD;
+	info: CutInfo;
+}
+export interface BadCut extends NoteBase {
+	type: CutType.BAD;
+	info: CutInfo;
+}
+export interface Miss extends NoteBase {
+	type: CutType.MISS;
+}
+export interface Bomb extends NoteBase {
+	type: CutType.BOMB;
+}
+export type Note = GoodCut | BadCut | Miss | Bomb;
+
+export enum ObstacleType {
+	FullHeight = 0,
+	Top,
+	Free
+}
+
+export interface Wall {
+	lineIndex: number;
+	type: ObstacleType;
+	width: number;
+	energy: number;
+	time: number;
+	spawnTime: number;
+}
+
+export interface Height {
+	height: number;
+	time: number;
+}
+
+export interface Pause {
+	duration: BigInt;
+	time: number;
+}
+
+/// A BSOR replay file
+export class Replay {
+	/// Version info
+	version: {
+		mod: string,
+		game: string
+	};
+	/// Play start
+	timestamp: Date;
+	/// Player info
+	player: {
+		id: string,
+		name: string,
+		platform: string
+	};
+	/// Headset info
+	headset: {
+		trackingSystem: string,
+		hmd: string,
+		controller: string
+	};
+	/// Map info
+	map: {
+		hash: string,
+		songName: string,
+		mapper: string,
+		difficulty: string
+	};
+	/// Play info
+	play: {
+		score: number;
+		mode: string;
+		environment: string;
+		modifiers: string;
+		jumpDistance: number;
+		leftHanded: boolean;
+		height: number;
+	}
+	/// Time info
+	time: {
+		start: number;
+		fail: number;
+		speed: number;
+	}
+	/// Frames
+	frames: Frame[];
+	/// Notes
+	notes: Note[];
+	/// Walls
+	walls: Wall[];
+	/// Height
+	height: Height[];
+	/// Pause
+	pause: Pause[];
+
+	constructor(data: Uint8Array) {
+		let pos = 0;
+		let buffer = new ArrayBuffer(4);
+		const bufferF32 = new Float32Array(buffer);
+		const bufferU8 = new Uint8Array(buffer);
+
+		function raise(msg: string): never {
+			throw new BSORError(msg);
+		}
+
+		function get(n: number): number {
+			return data[n] ?? raise("Unexpected EOF");
+		}
+
+		function byte(): number {
+			return get(pos++);
+		}
+
+		function int(): number {
+			pos += 4;
+			return (get(pos-4)) | (get(pos-3) << 8) | (get(pos-2) << 16) | (get(pos-1) << 24);
+		}
+
+		function long(): BigInt {
+			const lower = int();
+			const upper = int();
+			return BigInt(upper)*BigInt("0x100000000") + BigInt(lower);
+		}
+
+		function float(): number {
+			bufferU8[0] = byte();
+			bufferU8[1] = byte();
+			bufferU8[2] = byte();
+			bufferU8[3] = byte();
+			return bufferF32[0]!;
+		}
+
+		function bool(): boolean {
+			return byte() != 0;
+		}
+
+		function string(): string {
+			const length = int();
+			pos += length;
+			return new TextDecoder().decode(new Uint8Array(data.buffer, pos-length, length));
+		}
+		function vector(): Vector3 {
+			return new Vector3(float(), float(), float());
+		}
+		function quaternion(): Quaternion {
+			return new Quaternion(float(), float(), float(), float());
+		}
+		// magic number
+		if(int() != 0x442D3D69)
+			raise("Invalid magic number");
+		if(byte() != 1)
+			raise("Unknown BSOR version");
+		if(byte() != 0)
+			raise("Expected info structure start");
+		this.version = {
+			mod: string(),
+			game: string()
+		};
+		this.timestamp = new Date(Number(string())*1000);
+		this.player = {
+			id: string(),
+			name: string(),
+			platform: string()
+		};
+		this.headset = {
+			trackingSystem: string(),
+			hmd: string(),
+			controller: string()
+		};
+		this.map = {
+			hash: string(),
+			songName: string(),
+			mapper: string(),
+			difficulty: string()
+		};
+		this.play = {
+			score: int(),
+			mode: string(),
+			environment: string(),
+			modifiers: string(),
+			jumpDistance: float(),
+			leftHanded: bool(),
+			height: float()
+		};
+		this.time = {
+			start: float(),
+			fail: float(),
+			speed: float()
+		};
+		this.frames = [];
+		if(byte() != 1)
+			raise("Expected frame array start");
+		const frameCount = int();
+		for(let i = 0; i < frameCount; i++) {
+			this.frames.push({
+				time: float(),
+				fps: int(),
+				head: {
+					position: vector(),
+					rotation: quaternion()
+				},
+				leftHand: {
+					position: vector(),
+					rotation: quaternion()
+				},
+				rightHand: {
+					position: vector(),
+					rotation: quaternion()
+				}
+			});
+		}
+		if(byte() != 2)
+			raise("Expected note array start");
+		this.notes = [];
+		const noteCount = int();
+		for(let i = 0; i < noteCount; i++) {
+			const id = int();
+			const scoringType = Math.floor(id/10000);
+			const lineIndex = Math.floor(id/1000)%10;
+			const lineLayer = Math.floor(id/100)%10;
+			const color = Math.floor(id/10)%10 as NoteColor;
+			const cutDirection = id%10 as CutDirection;
+			const time = float();
+			const spawnTime = float();
+			const type = int() as CutType;
+			switch(type) {
+				case CutType.MISS:
+				case CutType.BOMB:
+					this.notes.push({
+						type,
+						scoringType,
+						lineIndex,
+						lineLayer,
+						color,
+						cutDirection,
+						time,
+						spawnTime
+					})
+					break;
+				case CutType.GOOD:
+				case CutType.BAD:
+					this.notes.push({
+						type,
+						scoringType,
+						lineIndex,
+						lineLayer,
+						color,
+						cutDirection,
+						time,
+						spawnTime,
+						info: {
+							ok: {
+								speed: bool(),
+								direction: bool(),
+								saberType: bool(),
+							},
+							wasCutTooSoon: bool(),
+							saber: {
+								speed: float(),
+								dir: vector(),
+								type: int() as Saber
+							},
+							cut: {
+								timeDeviation: float(),
+								dirDeviation: float(),
+								point: vector(),
+								normal: vector(),
+								distanceToCenter: float(),
+								angle: float(),
+								beforeCutRating: float(),
+								afterCutRating: float()
+							}
+						}
+					})
+					break;
+			}
+		}
+		this.walls = [];
+		if(byte() != 3)
+			raise("Expected wall array start");
+		const wallCount = int();
+		for(let i = 0; i < wallCount; i++) {
+			const id = int();
+			this.walls.push({
+				lineIndex: Math.floor(id/100),
+				type: Math.floor(id/10)%10 as ObstacleType,
+				width: id%10,
+				energy: float(),
+				time: float(),
+				spawnTime: float()
+			})
+		}
+		this.height = [];
+		if(byte() != 4)
+			raise("Expected height array start");
+		const heightCount = int();
+		for(let i = 0; i < heightCount; i++) {
+			this.height.push({
+				height: float(),
+				time: float()
+			})
+		}
+		this.pause = [];
+		if(byte() != 5)
+			raise("Expected pause array start");
+		const pauseCount = int();
+		for(let i = 0; i < pauseCount; i++) {
+			this.pause.push({
+				duration: long(),
+				time: float()
+			})
+		}
+
+	}
+}
+
+class BSORError extends Error {
+	constructor(msg: string) {
+		super(msg);
+	}
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -30,6 +30,7 @@ import batToExeHandler from "./batToExe.ts";
 import textEncodingHandler from "./textEncoding.ts";
 import libopenmptHandler from "./libopenmpt.ts";
 import lzhHandler from "./lzh.ts";
+import bsorHandler from "./bsor.ts";
 
 const handlers: FormatHandler[] = [];
 try { handlers.push(new svgTraceHandler()) } catch (_) { };
@@ -64,5 +65,6 @@ try { handlers.push(new textEncodingHandler()) } catch (_) { };
 try { handlers.push(new libopenmptHandler()) } catch (_) { };
 try { handlers.push(new lzhHandler()) } catch (_) { };
 try { handlers.push(new pandocHandler()) } catch (_) { };
+try { handlers.push(new bsorHandler()) } catch (_) { };
 
 export default handlers;


### PR DESCRIPTION
Adds the [Beat Saber Open Replay (BSOR)](https://github.com/BeatLeader/BS-Open-Replay) format used by BeatLeader and other Beat Saber tools.

Similar to the SPPD handler, this uses THREE.js to render a bunch of frames which can then be converted to a video via ffmpeg.

(this is probably the worst replay viewer ever created lol)