### PR TITLE
Fixed issues with text to html conversion

### DIFF
--- a/src/handlers/canvasToBlob.ts
+++ b/src/handlers/canvasToBlob.ts
@@ -57,7 +57,7 @@ class canvasToBlobHandler implements FormatHandler {
         this.#canvas.width = maxLineWidth;
         this.#canvas.height = Math.floor(fontSize * lines.length + footerPadding);
 
-        if (outputFormat.mime === "image/jpeg") {
+        if (outputFormat.category === "image" || outputFormat.category?.includes("image")) {
           this.#ctx.fillStyle = "white";
           this.#ctx.fillRect(0, 0, this.#canvas.width, this.#canvas.height);
         }

--- a/src/handlers/htmlEmbed.ts
+++ b/src/handlers/htmlEmbed.ts
@@ -47,8 +47,9 @@ class htmlEmbedHandler implements FormatHandler {
         const text = decoder.decode(inputFile.bytes)
           .replaceAll("&", "&amp;")
           .replaceAll("<", "&lt;")
-          .replaceAll(">", "&gt;");
-        html += `<p>${text}</p><br>`;
+          .replaceAll(">", "&gt;")
+          .replaceAll("\n", "<br>");
+        html += `<p>${text}</p>`;
       }
     } else {
       for (const inputFile of inputFiles) {


### PR DESCRIPTION
Linebreaks were missing from the file when converting from txt to HTML

The `<p>` tag already create new line, so removing the extra `<br>` from the end of file

Fixed canvas not using white background for non jpeg images (issue when txt -> html blob -> png)
The HTML blob to PNG has an issue where the canvas width is not increased, which is not fixed in this pr.