### PR TITLE
Add support for Magic: The Gathering Arena (.mtga) files (#347)

### DIFF
--- a/src/handlers/sqlite.ts
+++ b/src/handlers/sqlite.ts
@@ -20,6 +20,16 @@ class sqlite3Handler implements FormatHandler {
         internal: "sqlite3",
         category: "database"
       },
+      {
+        name: "Magic: The Gathering Arena Database",
+        format: "mtga",
+        extension: "mtga",
+        mime: "application/vnd.sqlite3",
+        from: true,
+        to: false,
+        internal: "sqlite3",
+        category: "database"
+      },
       // Lossy because extracts only tables  
       CommonFormats.CSV.builder("csv").allowTo()
     ];

--- a/src/normalizeMimeType.ts
+++ b/src/normalizeMimeType.ts
@@ -16,6 +16,7 @@ function normalizeMimeType (mime: string) {
     case "application/lha": return "application/x-lzh-compressed";
     case "application/x-lha": return "application/x-lzh-compressed";
     case "application/x-lzh": return "application/x-lzh-compressed";
+    case "application/x-mtga": return "application/vnd.sqlite3";
     case "audio/x-flac": return "audio/flac";
     case "application/font-sfnt": return "font/ttf";
     case "application/x-font-ttf": return "font/ttf"; // both TTF & OTF


### PR DESCRIPTION
MTGA files are SQLite3 databases used by Magic the Gathering: Arena.
Added format alias to enable file identification and conversion.

Changes:
- Added MTGA format entry to SQLite handler with .mtga extension
- Added MIME type normalization for application/x-mtga
- MTGA files now work exactly like SQLite3 databases
- Can be converted to CSV format (table extraction)

Closes #347