### PR TITLE
build: Create bun script for buildCache.js

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,7 +39,7 @@ jobs:
           bun run build
 
       - name: Generate cache
-        run: bun run buildCache.js dist/cache.json
+        run: bun run cache:build
 
       - name: Test traversion graph
         run: bun test test/TraversionGraph.test.ts

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ ARG VITE_COMMIT_SHA
 ENV VITE_COMMIT_SHA=$VITE_COMMIT_SHA
 
 RUN bun run build
-RUN bun run buildCache.js dist/cache.json
+RUN bun run cache:build
 
 FROM nginx:stable-alpine AS runtime
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "cache:build" : "bun run buildCache.js dist/cache.json",
     "preview": "vite preview",
     "docker": "bun run docker:build && bun run docker:up",
     "docker:build": "docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml build --build-arg VITE_COMMIT_SHA=$(git rev-parse HEAD)",


### PR DESCRIPTION
This PR removes duplicate usage of `bun run buildCache.js` and adds a new Bun script called `cache:build`.

Needed for an upcoming Electron PR (related to issue #360), which will need to have a built cache inside the app.