### PR TITLE
SVG -> img conversion stack overflow fix

### DIFF
--- a/src/handlers/canvasToBlob.ts
+++ b/src/handlers/canvasToBlob.ts
@@ -78,7 +78,7 @@ class canvasToBlobHandler implements FormatHandler {
         // For SVG, convert to data URL to avoid "Tainted canvases may not be exported" error
         const url =
           inputFormat.mime === "image/svg+xml"
-            ? `data:${inputFormat.mime};base64,${btoa(String.fromCharCode(...inputFile.bytes))}`
+            ? `data:${inputFormat.mime};base64,${btoa(inputFile.bytes.reduce((str, byte) => str + String.fromCharCode(byte), ''))}`
             : URL.createObjectURL(blob);
 
         const image = new Image();


### PR DESCRIPTION
This PR fixes a bug when too big of an SVG causes `RangeError: Maximum call stack size exceeded` (mainly when converting fonts to images, since .svg files generated from fonts can be thousands of lines long).