### PR TITLE
fixed ffmpeg does not support that sample rate

### DIFF
--- a/src/handlers/FFmpeg.ts
+++ b/src/handlers/FFmpeg.ts
@@ -279,6 +279,10 @@ class FFmpegHandler implements FormatHandler {
         if (typeof newSize !== "string") throw stdout;
         return this.doConvert(inputFiles, inputFormat, outputFormat, [...oldArgs, "-s", newSize]);
       }
+      if (stdout.includes("does not support that sample rate, choose from (") && !oldArgs.includes("-ar")) {
+        const acceptedBitrate = stdout.split("does not support that sample rate, choose from (")[1].split(", ")[0];
+        return this.doConvert(inputFiles, inputFormat, outputFormat, [...oldArgs, "-ar", acceptedBitrate]);
+      }
 
       throw stdout;
     }


### PR DESCRIPTION
Fixes #126 

Some formats do not support the audio bitrate of the input file. This tells ffmpeg to change it to a supported bitrate.