### PR TITLE
buildCache.js: minify JSON file if specified

### DIFF
--- a/buildCache.js
+++ b/buildCache.js
@@ -1,5 +1,14 @@
 import puppeteer from "puppeteer";
 
+const minify = (process.argv[3] === "--minify");
+
+const outputPath = process.argv[2] || "cache.json";
+// delete previous cache.json so regeneration is forced to happen
+const outputFile = Bun.file(outputPath);
+if (await outputFile.exists()) {
+  await outputFile.delete();
+}
+
 const server = Bun.serve({
   async fetch (req) {
     const path = new URL(req.url).pathname.replace("/convert/", "") || "index.html";
@@ -27,10 +36,17 @@ await Promise.all([
   page.goto("http://localhost:8080/convert/index.html")
 ]);
 
-const cacheJSON = await page.evaluate(() => {
+const cacheJSON = await page.evaluate((minify) => {
+  if (minify === true) {
+    return JSON.stringify(
+      JSON.parse(
+        window.printSupportedFormatCache()
+      )
+    );
+  }
   return window.printSupportedFormatCache();
-});
-const outputPath = process.argv[2] || "cache.json";
+}, minify);
+
 await Bun.write(outputPath, cacheJSON);
 
 await browser.close();

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "cache:build" : "bun run buildCache.js dist/cache.json",
+    "cache:build" : "bun run buildCache.js dist/cache.json --minify",
+    "cache:build:dev" : "bun run buildCache.js dist/cache.json",
     "preview": "vite preview",
     "docker": "bun run docker:build && bun run docker:up",
     "docker:build": "docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml build --build-arg VITE_COMMIT_SHA=$(git rev-parse HEAD)",


### PR DESCRIPTION
This PR adds a switch that can minimise the size of the cache.json file. On the latest commits, it currently saves 76 KB, from 197 KB (20.0 kB gzip response) to 121 KB (18.5 kB gzip).

`cache:build` has the switch to minify the JSON. `cache:build:dev` turns it off, so the file can be debugged for any issues.