### PR TITLE
threejs: add OBJ and GLTF handling

### DIFF
--- a/src/handlers/threejs.ts
+++ b/src/handlers/threejs.ts
@@ -3,6 +3,7 @@ import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
 
 import * as THREE from "three";
 import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
+import { OBJLoader } from "three/addons/loaders/OBJLoader.js";
 import type { GLTF } from "three/addons/loaders/GLTFLoader.js";
 
 class threejsHandler implements FormatHandler {
@@ -18,6 +19,26 @@ class threejsHandler implements FormatHandler {
       to: false,
       internal: "glb",
       category: "model"
+    },
+    {
+      name: "GL Transmission Format",
+      format: "gltf",
+      extension: "gltf",
+      mime: "model/gltf+json",
+      from: true,
+      to: false,
+      internal: "glb",
+      category: "model"
+    },
+    {
+      name: "Waveform OBJ",
+      format: "obj",
+      extension: "obj",
+      mime: "model/obj",
+      from: true,
+      to: false,
+      internal: "obj",
+      category: "model",
     },
     CommonFormats.PNG.supported("png", false, true),
     CommonFormats.JPEG.supported("jpeg", false, true),
@@ -36,7 +57,7 @@ class threejsHandler implements FormatHandler {
 
   async doConvert (
     inputFiles: FileData[],
-    _inputFormat: FileFormat,
+    inputFormat: FileFormat,
     outputFormat: FileFormat
   ): Promise<FileData[]> {
     const outputFiles: FileData[] = [];
@@ -46,19 +67,35 @@ class threejsHandler implements FormatHandler {
       const blob = new Blob([inputFile.bytes as BlobPart]);
       const url = URL.createObjectURL(blob);
 
-      const gltf: GLTF = await new Promise((resolve, reject) => {
-        const loader = new GLTFLoader();
-        loader.load(url, resolve, undefined, reject);
-      });
+      let object: THREE.Group<THREE.Object3DEventMap>;
 
-      const bbox = new THREE.Box3().setFromObject(gltf.scene);
+      switch (inputFormat.internal) {
+        case "glb": {
+          const gltf: GLTF = await new Promise((resolve, reject) => {
+            const loader = new GLTFLoader();
+            loader.load(url, resolve, undefined, reject);
+          });
+          object = gltf.scene;
+          break;
+        }
+        case "obj":
+          object = await new Promise((resolve, reject) => {
+            const loader = new OBJLoader();
+            loader.load(url, resolve, undefined, reject);
+          });
+          break;
+        default:
+          throw new Error("Invalid input format");
+      }
+
+      const bbox = new THREE.Box3().setFromObject(object);
       bbox.getCenter(this.camera.position);
       this.camera.position.z = bbox.max.z * 2;
 
       this.scene.background = new THREE.Color(0x424242);
-      this.scene.add(gltf.scene);
+      this.scene.add(object);
       this.renderer.render(this.scene, this.camera);
-      this.scene.remove(gltf.scene);
+      this.scene.remove(object);
 
       const bytes: Uint8Array = await new Promise((resolve, reject) => {
         this.renderer.domElement.toBlob((blob) => {


### PR DESCRIPTION
.gltf is handled the same as .glb files, thus the internal "glb" format is used.
.obj uses the three.js OBJLoader.

partially resolves #411 (doesn't implement OBJ<->GLTF conversion)