### PR TITLE
Added support for iTunes Database file.

### DIFF
--- a/src/handlers/sqlite.ts
+++ b/src/handlers/sqlite.ts
@@ -30,6 +30,16 @@ class sqlite3Handler implements FormatHandler {
         internal: "sqlite3",
         category: "database"
       },
+      {
+        name: "iTunes Database",
+        format: "itdb",
+        extension: "itdb",
+        mime: "application/vnd.sqlite3",
+        from: true,
+        to: false,
+        internal: "sqlite3",
+        category: "database"
+      },
       // Lossy because extracts only tables  
       CommonFormats.CSV.builder("csv").allowTo()
     ];

--- a/src/normalizeMimeType.ts
+++ b/src/normalizeMimeType.ts
@@ -19,6 +19,7 @@ function normalizeMimeType (mime: string) {
     case "application/x-lha": return "application/x-lzh-compressed";
     case "application/x-lzh": return "application/x-lzh-compressed";
     case "application/x-mtga": return "application/vnd.sqlite3";
+    case "application/x-itunes-itdb": return "application/vnd.sqlite3"; // Not required, but just in case
     case "audio/x-flac": return "audio/flac";
     case "application/font-sfnt": return "font/ttf";
     case "application/x-font-ttf": return "font/ttf"; // both TTF & OTF


### PR DESCRIPTION
Added support for iTunes Database file, since the .itdb file format is just a renamed .db or .sqlite3 file. Even the file signature of the .itdb file is "SQLite format 3", which is the same as any sqlite3 file (.db or .sqlite3).