### PR TITLE
fix: replace unstable jsr @std/yaml with npm yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@flo-audio/reflo": "^0.1.2",
     "@imagemagick/magick-wasm": "^0.0.37",
     "@sqlite.org/sqlite-wasm": "^3.51.2-build6",
-    "@std/yaml": "npm:@jsr/std__yaml",
+    "yaml": "^2.8.2",
     "@stringsync/vexml": "^0.1.8",
     "@toon-format/toon": "^2.1.0",
     "@types/bun": "^1.3.9",

--- a/src/handlers/json.ts
+++ b/src/handlers/json.ts
@@ -1,7 +1,7 @@
 import CommonFormats from "src/CommonFormats.ts";
 import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
 import parseXML from "./envelope/parseXML.js";
-import * as yaml from "@std/yaml";
+import * as yaml from "yaml";
 
 /// Converts things to JSON
 export class toJsonHandler implements FormatHandler {


### PR DESCRIPTION
replaces the jsr-sourced yaml which has proven to not be a stable source, with the npm-sourced yaml
