### PR TITLE
Fixed ImageMagick: Files to ICO

### DIFF
--- a/src/handlers/ImageMagick.ts
+++ b/src/handlers/ImageMagick.ts
@@ -3,7 +3,8 @@ import {
   Magick,
   MagickFormat,
   MagickImageCollection,
-  MagickReadSettings
+  MagickReadSettings,
+  MagickGeometry
 } from "@imagemagick/magick-wasm";
 
 import mime from "mime";
@@ -92,6 +93,12 @@ class ImageMagickHandler implements FormatHandler {
             while (fileCollection.length > 0) {
               const image = fileCollection.shift();
               if (!image) break;
+
+              if(outputFormat.format == "ico" && (image.width > 256 || image.height > 256)) {
+                const geometry = new MagickGeometry(256, 256);
+                image.resize(geometry);
+              }
+
               outputCollection.push(image);
             }
           });


### PR DESCRIPTION
fixes #464 

Resize images when it is converted to ico if the image is bigger than the ico size limit (256 px)