### PR TITLE
fixed anyinput formats being unreachable

### DIFF
--- a/src/TraversionGraph.ts
+++ b/src/TraversionGraph.ts
@@ -31,6 +31,7 @@ const LOG_FREQUENCY = 1000;
 
 export interface Node {
     identifier: string;
+    format: FileFormat;
     edges: Array<number>;
 };
 
@@ -138,6 +139,7 @@ export class TraversionGraph {
 
         console.log("Initializing traversion graph...");
         const startTime = performance.now();
+
         let handlerIndex = 0;
         supportedFormatCache.forEach((formats, handler) => {
             let fromIndices: Array<{format: FileFormat, index: number}> = [];
@@ -149,6 +151,7 @@ export class TraversionGraph {
                     index = this.nodes.length;
                     this.nodes.push({
                         identifier: formatIdentifier,
+                        format: format,
                         edges: []
                     });
                 }
@@ -175,6 +178,52 @@ export class TraversionGraph {
             });
             handlerIndex++;
         });
+
+        // Add edges for handlers with supportAnyInput.
+        // These handlers can accept any format as input, so we create edges
+        // from every known format node to their output formats.
+        handlers.forEach((handler, hIndex) => {
+            if (!handler.supportAnyInput) return;
+            const formats = supportedFormatCache.get(handler.name);
+            if (!formats) return;
+
+            // Collect output format node indices for this handler
+            const toEntries: Array<{format: FileFormat, index: number}> = [];
+            for (const f of formats) {
+                if (!f.to) continue;
+                const id = f.mime + `(${f.format})`;
+                const idx = this.nodes.findIndex(n => n.identifier === id);
+                if (idx !== -1) toEntries.push({ format: f, index: idx });
+            }
+
+            // Create edges from every known format node to each output format
+            this.nodes.forEach((fromNode, fromIndex) => {
+                for (const to of toEntries) {
+                    if (fromIndex === to.index) continue;
+                    // Skip if an edge already exists from this node to this target via this handler
+                    const alreadyExists = fromNode.edges.some(eIdx =>
+                        this.edges[eIdx].to.index === to.index && this.edges[eIdx].handler === handler.name
+                    );
+                    if (alreadyExists) continue;
+
+                    const cost = this.costFunction(
+                        { format: fromNode.format, index: fromIndex },
+                        { format: to.format, index: to.index },
+                        strictCategories,
+                        handler.name,
+                        hIndex
+                    );
+                    this.edges.push({
+                        from: { format: fromNode.format, index: fromIndex },
+                        to: { format: to.format, index: to.index },
+                        handler: handler.name,
+                        cost
+                    });
+                    this.nodes[fromIndex].edges.push(this.edges.length - 1);
+                }
+            });
+        });
+
         const endTime = performance.now();
         console.log(`Traversion graph initialized in ${(endTime - startTime).toFixed(2)} ms with ${this.nodes.length} nodes and ${this.edges.length} edges.`);
     }
@@ -246,7 +295,7 @@ export class TraversionGraph {
      */
     public getData() : {nodes: Node[], edges: Edge[], categoryChangeCosts: CategoryChangeCost[], categoryAdaptiveCosts: CategoryAdaptiveCost[]} {
         return {
-            nodes: this.nodes.map(node => ({identifier: node.identifier, edges: [...node.edges]})),
+            nodes: this.nodes.map(node => ({identifier: node.identifier, format: {...node.format}, edges: [...node.edges]})),
             edges: this.edges.map(edge => ({
                 from: {format: {...edge.from.format}, index: edge.from.index},
                 to: {format: {...edge.to.format}, index: edge.to.index},

--- a/src/TraversionGraph.ts
+++ b/src/TraversionGraph.ts
@@ -26,6 +26,7 @@ const DEFAULT_CATEGORY_CHANGE_COST : number = 0.6; // Default cost for category 
 const LOSSY_COST_MULTIPLIER : number = 1.4; // Cost multiplier for lossy conversions. Higher values will make the algorithm prefer lossless conversions more strongly.
 const HANDLER_PRIORITY_COST : number = 0.02; // Cost multiplier for handler priority. Higher values will make the algorithm prefer handlers with higher priority more strongly.
 const FORMAT_PRIORITY_COST : number = 0.05; // Cost multiplier for format priority. Higher values will make the algorithm prefer formats with higher priority more strongly.
+const ANY_INPUT_COST : number = 2; // Extra cost for edges created via supportAnyInput. Discourages generic "pack" conversions so the algorithm prefers more specific conversion paths (e.g. rename-then-convert over wrapping a file as-is).
 
 const LOG_FREQUENCY = 1000;
 
@@ -212,7 +213,7 @@ export class TraversionGraph {
                         strictCategories,
                         handler.name,
                         hIndex
-                    );
+                    ) + ANY_INPUT_COST;
                     this.edges.push({
                         from: { format: fromNode.format, index: fromIndex },
                         to: { format: to.format, index: to.index },

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,13 +13,6 @@ let selectedFiles: File[] = [];
  */
 let simpleMode: boolean = true;
 
-/** Handlers that support conversion from any formats. */
-const conversionsFromAnyInput: ConvertPathNode[] = handlers
-.filter(h => h.supportAnyInput && h.supportedFormats)
-.flatMap(h => h.supportedFormats!
-  .filter(f => f.to)
-  .map(f => ({ handler: h, format: f})))
-
 const ui = {
   fileInput: document.querySelector("#file-input") as HTMLInputElement,
   fileSelectArea: document.querySelector("#file-area") as HTMLDivElement,
@@ -365,7 +358,7 @@ async function attemptConvertPath (files: FileData[], path: ConvertPathNode[]) {
         c.from
         && c.mime === path[i].format.mime
         && c.format === path[i].format.format
-      )!;
+      ) || (handler.supportAnyInput ? path[i].format : undefined);
       files = (await Promise.all([
         handler.doConvert(files, inputFormat, path[i + 1].format),
         // Ensure that we wait long enough for the UI to update

--- a/src/main.ts
+++ b/src/main.ts
@@ -359,6 +359,7 @@ async function attemptConvertPath (files: FileData[], path: ConvertPathNode[]) {
         && c.mime === path[i].format.mime
         && c.format === path[i].format.format
       ) || (handler.supportAnyInput ? path[i].format : undefined);
+      if (!inputFormat) throw `Handler "${handler.name}" doesn't support the "${path[i].format.format}" format.`;
       files = (await Promise.all([
         handler.doConvert(files, inputFormat, path[i + 1].format),
         // Ensure that we wait long enough for the UI to update

--- a/test/TraversionGraph.test.ts
+++ b/test/TraversionGraph.test.ts
@@ -22,6 +22,9 @@ const handlers : FormatHandler[] = [
     CommonFormats.WAV.supported("wav", true, true, true),
     CommonFormats.MP4.supported("mp4", true, true, true)
   ], false),
+  new MockedHandler("archiver", [
+    CommonFormats.ZIP.builder("zip").allowTo().markLossless().withCategory("archive"),
+  ], true),
 ]
 
 let supportedFormatCache = new Map<string, FileFormat[]>();
@@ -193,4 +196,22 @@ test('remove adaptive category costs should affect pathfinding\n', async () => {
   expect(extractedPaths.length).toBeGreaterThan(0);
   expect(extractedNewPaths.length).toBeGreaterThan(0);
   expect(extractedNewPaths[0]).not.toEqual(extractedPaths[0]);
+});
+
+test('should find path from image to archive via anyinput\n', async () => {
+  const graph = new TraversionGraph();
+  graph.init(supportedFormatCache, handlers);
+
+  const paths = graph.searchPath(
+    new ConvertPathNode(handlers.find(h => h.name === "canvasToBlob")!, CommonFormats.PNG.supported("png", true, true, true)),
+    new ConvertPathNode(handlers.find(h => h.name === "archiver")!, CommonFormats.ZIP.supported("zip", false, true, true)),
+    true
+  );
+  let extractedPaths = [];
+  for await (const path of paths)
+    extractedPaths.push(path);
+  expect(extractedPaths.length).toBeGreaterThan(0);
+  expect(extractedPaths[0][0].format.format).toBe("png");
+  expect(extractedPaths[0][extractedPaths[0].length - 1].format.format).toBe("zip");
+  expect(extractedPaths[0][extractedPaths[0].length - 1].handler.name).toBe("archiver");
 });


### PR DESCRIPTION
fixing a bug i found when making my tar pr: anyInput handlers did not work at all. (if you convert anything like a png or a text file to a zip or lzh, it always goes through docx and html instead of direct conversion)

the second loop is needed because we need to construct all anyinput paths after all the normal paths are done in order to prioritize nonanyinput paths.

the only issue rn is that anyinput is all or nothing rn - so something like lzh tries to convert anything we try to convert to zip (as it declares that it can accept "any input" and that it produces a zip file as a result) and obviously fails with a (harmless) console error. thatd need deeper changes though, so i left it like that and even with that it works perfectly fine.