### PR TITLE
Add WMV (Windows Media Video) support

### DIFF
--- a/src/CommonFormats.ts
+++ b/src/CommonFormats.ts
@@ -177,6 +177,13 @@ const CommonFormats = {
         "video/mp4",
         Category.VIDEO
     ),
+    WMV: new FormatDefinition(
+        "Windows Media Video",
+        "wmv",
+        "wmv",
+        "video/x-ms-asf",
+        Category.VIDEO
+    ),
     // archive
     ZIP: new FormatDefinition(
         "ZIP Archive",

--- a/src/handlers/FFmpeg.ts
+++ b/src/handlers/FFmpeg.ts
@@ -19,7 +19,8 @@ class FFmpegHandler implements FormatHandler {
     ["matroska", "Matroska / WebM"],
     ["mov", "QuickTime / MOV"],
     ["3gp", "3GPP Multimedia Container"],
-    ["3g2", "3GPP2 Multimedia Container"]
+    ["3g2", "3GPP2 Multimedia Container"],
+    ["asf", "Windows Media Video (WMV)"]
   ]);
 
   public name: string = "FFmpeg";
@@ -221,6 +222,18 @@ class FFmpegHandler implements FormatHandler {
       internal: "mov"
     });
 
+    // Add .wmv (Windows Media Video) support - uses ASF container
+    this.supportedFormats.push({
+      name: "Windows Media Video",
+      format: "wmv",
+      extension: "wmv",
+      mime: "video/x-ms-asf",
+      from: true,
+      to: true,
+      internal: "asf",
+      category: "video"
+    });
+
     // Normalize Bink metadata to ensure ".bik" files are detected by extension.
     const binkFormats = this.supportedFormats.filter(f =>
       f.internal === "bink"
@@ -284,6 +297,8 @@ class FFmpegHandler implements FormatHandler {
       command.push("-vf", "setsar=1", "-target", "ntsc-dvd", "-pix_fmt", "rgb24");
     } else if (outputFormat.internal === "vcd") {
       command.push("-vf", "scale=352:288,setsar=1", "-target", "pal-vcd", "-pix_fmt", "rgb24");
+    } else if (outputFormat.internal === "asf") {
+      command.push("-b:v", "15M", "-b:a", "192k");
     }
     if (args) command.push(...args);
     command.push("output");

--- a/src/normalizeMimeType.ts
+++ b/src/normalizeMimeType.ts
@@ -33,6 +33,7 @@ function normalizeMimeType (mime: string) {
     case "application/musicxml": return "application/vnd.recordare.musicxml+xml";
     case "application/musicxml+xml": return "application/vnd.recordare.musicxml+xml";
     case "text/mathml": return "application/mathml+xml";
+    case "video/x-ms-wmv": return "video/x-ms-asf";
   }
   return mime;
 }


### PR DESCRIPTION
Adds support for WMV input and output by mapping it to the ASF container
format already handled by FFmpeg.

**Changes:**
- Add WMV `FormatDefinition` in `CommonFormats.ts`
- Add `asf` → "Windows Media Video (WMV)" friendly name mapping in FFmpeg handler
- Add manual WMV format entry using `internal: "asf"` (same pattern as QTA)
- Add `video/x-ms-wmv` → `video/x-ms-asf` MIME normalization
- Set encode bitrate to 15 Mbps video / 192 kbps audio (FFmpeg's default ~200 kbps is too low for the older WMV codecs)