### PR TITLE
fix(batchHandler): Don't escape "!", handle whitespace-only lines

### DIFF
--- a/src/handlers/batch.ts
+++ b/src/handlers/batch.ts
@@ -40,7 +40,6 @@ class batchHandler implements FormatHandler {
               case "|": buf.push("^|"); break;
               case "<": buf.push("^<"); break;
               case ">": buf.push("^>"); break;
-              case "!": buf.push("^^!"); break;
               default:  buf.push(ch);
             }
           }
@@ -52,7 +51,8 @@ class batchHandler implements FormatHandler {
         out = "@echo off\r\n";
 
         for (const line of lines) {
-          if (line === "") {
+          // Handles lines with only whitespace characters (which are trimmed by Command Prompt)
+          if (line.trim() === "") {
             out += "echo.\r\n";
           } else {
             out += `echo ${escapeBat(line)}\r\n`;


### PR DESCRIPTION
"^^!" is only required when EnableDelayedExpansion is set (which isn't by default). Otherwise, exclamation marks don't need to be escaped.

Because Command Prompt trims whitespace from the end of commands, whitespace-only lines cause it to output "ECHO is off.". The trim() method is used to handle whitespace-only lines.