### PR TITLE
fix: correctly name output files

### DIFF
--- a/src/handlers/FFmpeg.ts
+++ b/src/handlers/FFmpeg.ts
@@ -361,7 +361,7 @@ class FFmpegHandler implements FormatHandler {
     await this.#ffmpeg.deleteFile("output");
     await this.#ffmpeg.deleteFile("list.txt");
 
-    const baseName = inputFiles[0].name.split(".")[0];
+    const baseName = inputFiles[0].name.split(".").slice(0, -1).join(".");
     const name = baseName + "." + outputFormat.extension;
 
     return [{ bytes, name }];

--- a/src/handlers/ImageMagick.ts
+++ b/src/handlers/ImageMagick.ts
@@ -122,7 +122,7 @@ class ImageMagickHandler implements FormatHandler {
       });
     });
 
-    const baseName = inputFiles[0].name.split(".")[0];
+    const baseName = inputFiles[0].name.split(".").slice(0, -1).join(".");
     const name = baseName + "." + outputFormat.extension;
     return [{ bytes, name }];
 

--- a/src/handlers/bson.ts
+++ b/src/handlers/bson.ts
@@ -47,7 +47,7 @@ class bsonHandler implements FormatHandler {
           }
 
           const bsonResult = BSON.serialize(jsonData);
-          const name = file.name.split(".")[0] + ".bson";
+          const name = file.name.split(".").slice(0, -1).join(".") + ".bson";
 
           return {
             name,
@@ -64,7 +64,7 @@ class bsonHandler implements FormatHandler {
           const bsonData = BSON.deserialize(file.bytes);
           const text = JSON.stringify(bsonData);
 
-          const name = file.name.split(".")[0] + ".json";
+          const name = file.name.split(".").slice(0, -1).join(".") + ".json";
 
           return {
             name,

--- a/src/handlers/bsor.ts
+++ b/src/handlers/bsor.ts
@@ -38,7 +38,7 @@ class bsorHandler implements FormatHandler {
       const replay = new Replay(file.bytes);
       if(outputFormat.internal === "json") {
         return [{
-          name: file.name.split(".")[0] + ".json",
+          name: file.name.split(".").slice(0, -1).join(".") + ".json",
           bytes: new TextEncoder().encode(JSON.stringify(replay))
         }];
       }

--- a/src/handlers/canvasToBlob.ts
+++ b/src/handlers/canvasToBlob.ts
@@ -115,7 +115,7 @@ class canvasToBlobHandler implements FormatHandler {
         });
       }
 
-      const name = inputFile.name.split(".")[0] + "." + outputFormat.extension;
+      const name = inputFile.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension;
 
       outputFiles.push({ bytes, name });
 

--- a/src/handlers/envelope.ts
+++ b/src/handlers/envelope.ts
@@ -86,7 +86,7 @@ class envelopeHandler implements FormatHandler {
         ${await parser(inputFile.bytes)}
       </div>`;
       const bytes = encoder.encode(html);
-      const baseName = inputFile.name.split(".")[0];
+      const baseName = inputFile.name.split(".").slice(0, -1).join(".");
       const name = baseName + "." + outputFormat.extension;
       outputFiles.push({ bytes, name });
     }

--- a/src/handlers/espeakng.ts
+++ b/src/handlers/espeakng.ts
@@ -53,7 +53,7 @@ export class espeakngHandler implements FormatHandler {
       // decrease playback rate and increase playback sample rate
       wav.fromScratch(1, tts.sampleRate * 1.4, "32f", samples);
       return {
-        name: file.name.split(".")[0]+".wav",
+        name: file.name.split(".").slice(0, -1).join(".")+".wav",
         bytes: wav.toBuffer()
       }
     }))

--- a/src/handlers/flptojson.ts
+++ b/src/handlers/flptojson.ts
@@ -108,7 +108,7 @@ class flptojsonHandler implements FormatHandler {
         const encoder = new TextEncoder();
         const outputBytes = encoder.encode(jsonString);
 
-        const baseName = inputFile.name.split(".")[0];
+        const baseName = inputFile.name.split(".").slice(0, -1).join(".");
         const newName = `${baseName}.json`;
 
         outputFiles.push({

--- a/src/handlers/font.ts
+++ b/src/handlers/font.ts
@@ -84,7 +84,7 @@ function sfntToSvg(inputFile: FileData, encoder: TextEncoder) {
   </text>
 </svg>`;
       
-  const name = inputFile.name.split(".")[0] + ".svg";
+  const name = inputFile.name.split(".").slice(0, -1).join(".") + ".svg";
   const bytes = encoder.encode(svgFont);
 
   return { bytes, name };
@@ -186,7 +186,7 @@ function svgToOtf(inputFile: FileData, decoder: TextDecoder) {
   });
 
   const bytes = new Uint8Array(font.toArrayBuffer());
-  const name = inputFile.name.split(".")[0] + ".otf";
+  const name = inputFile.name.split(".").slice(0, -1).join(".") + ".otf";
 
   return { bytes, name };
 }
@@ -197,7 +197,7 @@ function svgToOtf(inputFile: FileData, decoder: TextDecoder) {
 function sfntToOtf(inputFile: FileData) {
   const font = parse(inputFile.bytes.buffer);
   const bytes = new Uint8Array(font.toArrayBuffer());
-  const name = inputFile.name.split(".")[0] + ".otf";
+  const name = inputFile.name.split(".").slice(0, -1).join(".") + ".otf";
 
   return { bytes, name };
 }
@@ -208,7 +208,7 @@ async function sfntToWoff2(inputFile: FileData): Promise<FileData> {
 
   const bytes = await compress(sfnt);
 
-  const name =inputFile.name.split(".")[0] + ".woff2";
+  const name =inputFile.name.split(".").slice(0, -1).join(".") + ".woff2";
 
   return { bytes, name };
 }

--- a/src/handlers/icns.ts
+++ b/src/handlers/icns.ts
@@ -211,7 +211,7 @@ class icnsHandler implements FormatHandler {
     const outputFiles: FileData[] = [];
 
     for (const inputFile of inputFiles) {
-      const baseName = inputFile.name.split(".")[0];
+      const baseName = inputFile.name.split(".").slice(0, -1).join(".");
       let bytes: Uint8Array;
 
       if (inputFormat.internal === "icns" && outputFormat.internal === "png") {

--- a/src/handlers/json.ts
+++ b/src/handlers/json.ts
@@ -25,7 +25,7 @@ export class toJsonHandler implements FormatHandler {
     outputFormat: FileFormat
   ): Promise<FileData[]> {
     return inputFiles.map(file => {
-      const name = file.name.split(".")[0]+".json";
+      const name = file.name.split(".").slice(0, -1).join(".")+".json";
       const text = new TextDecoder().decode(file.bytes);
       let object: any;
       switch(inputFormat.mime) {
@@ -92,7 +92,7 @@ export class fromJsonHandler {
     outputFormat: FileFormat
   ): Promise<FileData[]> {
     return inputFiles.map(file => {
-      const name = file.name.split(".")[0]+"."+outputFormat.extension;
+      const name = file.name.split(".").slice(0, -1).join(".")+"."+outputFormat.extension;
       let object = JSON.parse(new TextDecoder().decode(file.bytes));
       let text = "";
       switch(outputFormat.mime) {

--- a/src/handlers/jsonToC.ts
+++ b/src/handlers/jsonToC.ts
@@ -55,7 +55,7 @@ export default class jsonToCHandler implements FormatHandler {
             }
             
             if (bytes.length > 0) {
-                let name = file.name.split(".")[0] + "." + outputFormat.extension;
+                let name = file.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension;
                 outputFiles.push({name: name, bytes: bytes});
             }
             

--- a/src/handlers/mcSchematicHandler.ts
+++ b/src/handlers/mcSchematicHandler.ts
@@ -99,13 +99,13 @@ class mcSchematicHandler implements FormatHandler {
             if (outputFormat.internal === "litematic" || outputFormat.internal === "schem" || outputFormat.internal === "schematic") {
                 outBytes = gzipSync(outBytes);
                 outputFiles.push({
-                    name: file.name.split(".")[0] + "." + outputFormat.extension,
+                    name: file.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension,
                     bytes: outBytes
                 });
             } else {
                 // Not a native out-format (e.g., routing to JSON). Fallback to NBT extension for graph bridges.
                 outputFiles.push({
-                    name: file.name.split(".")[0] + ".nbt",
+                    name: file.name.split(".").slice(0, -1).join(".") + ".nbt",
                     bytes: outBytes
                 });
             }

--- a/src/handlers/mcmap.ts
+++ b/src/handlers/mcmap.ts
@@ -143,7 +143,7 @@ class mcMapHandler implements FormatHandler {
 
             for (const file of inputFiles) {
 
-                const fileName = file.name.split('.')[0]
+                const fileName = file.name.split(".").slice(0, -1).join(".")
 
                 let startDigit = 0
 

--- a/src/handlers/meyda.ts
+++ b/src/handlers/meyda.ts
@@ -161,7 +161,7 @@ class meydaHandler implements FormatHandler {
         wav.fromScratch(1, sampleRate, "32f", audioData);
 
         const bytes = wav.toBuffer();
-        const name = inputFile.name.split(".")[0] + "." + outputFormat.extension;
+        const name = inputFile.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension;
         outputFiles.push({ bytes, name });
 
       }
@@ -220,7 +220,7 @@ class meydaHandler implements FormatHandler {
             blob.arrayBuffer().then(buf => resolve(new Uint8Array(buf)));
           }, outputFormat.mime);
         });
-        const name = inputFile.name.split(".")[0] + "." + outputFormat.extension;
+        const name = inputFile.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension;
         outputFiles.push({ bytes, name });
 
       }

--- a/src/handlers/minecraftLangfileHandler.ts
+++ b/src/handlers/minecraftLangfileHandler.ts
@@ -82,10 +82,7 @@ class mclangHandler implements FormatHandler {
         }
 
         outputFiles.push({
-        name: file.name.replace(
-            `.${inputFormat.extension}`,
-            `.${outputFormat.extension}`
-        ),
+        name: file.name.split(".").slice(0, -1).join("."),
         bytes: new TextEncoder().encode(resultText)
         });
     }

--- a/src/handlers/n64rom.ts
+++ b/src/handlers/n64rom.ts
@@ -262,7 +262,7 @@ class n64romHandler implements FormatHandler {
         bytes = this.#fromZ64(z64Bytes, outputOrder);
       }
 
-      const baseName = inputFile.name.split(".")[0];
+      const baseName = inputFile.name.split(".").slice(0, -1).join(".");
       const name = baseName + "." + outputFormat.extension;
       outputFiles.push({ bytes, name });
     }

--- a/src/handlers/nbt.ts
+++ b/src/handlers/nbt.ts
@@ -57,7 +57,7 @@ class nbtHandler implements FormatHandler {
                     typeof value === 'bigint' ? value.toString() : value,
                 this.indent);
                 outputFiles.push({
-                    name: file.name.split(".")[0] + ".json",
+                    name: file.name.split(".").slice(0, -1).join(".") + ".json",
                     bytes: encoder.encode(j)
                 });
             }
@@ -70,7 +70,7 @@ class nbtHandler implements FormatHandler {
                 const obj = JSON.parse(text)
                 const bd = await NBT.write(obj)
                 outputFiles.push({
-                    name: file.name.split(".")[0] + `.${outputFormat.extension}`,
+                    name: file.name.split(".").slice(0, -1).join(".") + `.${outputFormat.extension}`,
                     bytes: bd
                 })
             }
@@ -83,7 +83,7 @@ class nbtHandler implements FormatHandler {
                 const nbt = NBT.parse(text)
                 const bd = await NBT.write(nbt)
                 outputFiles.push({
-                    name: file.name.split(".")[0] + `.${outputFormat.extension}`,
+                    name: file.name.split(".").slice(0, -1).join(".") + `.${outputFormat.extension}`,
                     bytes: bd
                 })
             }
@@ -96,7 +96,7 @@ class nbtHandler implements FormatHandler {
                     space: this.indent
                 })
                 outputFiles.push({
-                    name: file.name.split(".")[0] + ".snbt",
+                    name: file.name.split(".").slice(0, -1).join(".") + ".snbt",
                     bytes: encoder.encode(text)
                 })
             }
@@ -107,7 +107,7 @@ class nbtHandler implements FormatHandler {
         if (inputFormat.internal === "nbt" && (outputFormat.internal === "schem" || outputFormat.internal === "schematic")) {
             for (const file of inputFiles) {
                 outputFiles.push({
-                    name: file.name.split(".")[0] + `.${outputFormat.extension}`,
+                    name: file.name.split(".").slice(0, -1).join(".") + `.${outputFormat.extension}`,
                     bytes: gzipSync(file.bytes)
                 })
             }

--- a/src/handlers/pdftoimg.ts
+++ b/src/handlers/pdftoimg.ts
@@ -53,7 +53,7 @@ class pdftoimgHandler implements FormatHandler {
         pages: "all"
       });
 
-      const baseName = inputFile.name.split(".")[0];
+      const baseName = inputFile.name.split(".").slice(0, -1).join(".");
 
       for (let i = 0; i < images.length; i++) {
         const base64 = images[i].slice(images[i].indexOf(";base64,") + 8);

--- a/src/handlers/petozip.ts
+++ b/src/handlers/petozip.ts
@@ -103,7 +103,7 @@ class peToZipHandler implements FormatHandler {
           compressionOptions: { level: 9 }
         });
         
-        const baseName = inputFile.name.split(".")[0];
+        const baseName = inputFile.name.split(".").slice(0, -1).join(".");
         const newName = `${baseName}_pe_data.zip`;
 
         outputFiles.push({

--- a/src/handlers/pyTurtle.ts
+++ b/src/handlers/pyTurtle.ts
@@ -82,7 +82,7 @@ class pyTurtleHandler implements FormatHandler {
 
 
       const outputBytes = encoder.encode(python_code);
-      const newName = name.split(".")[0] + ".py";
+      const newName = name.split(".").slice(0, -1).join(".") + ".py";
       outputFiles.push({ name: newName, bytes: outputBytes });
     }
 

--- a/src/handlers/qoa-fu.ts
+++ b/src/handlers/qoa-fu.ts
@@ -117,7 +117,7 @@ this.supportedFormats.push(CommonFormats.FLAC.builder("flac").allowFrom(true).al
           wav.fromScratch(decoder.getChannels(), decoder.getSampleRate(), "16", audioData);
 
           const wavBytes = wav.toBuffer();
-          const name = inputFile.name.split(".")[0]+".wav";
+          const name = inputFile.name.split(".").slice(0, -1).join(".")+".wav";
           outputFiles.push({bytes: wavBytes, name});
         }
     } else { // any audio => QOA
@@ -157,7 +157,7 @@ this.supportedFormats.push(CommonFormats.FLAC.builder("flac").allowFrom(true).al
         }
 
         const qoaBytes = encoder.getData();
-        const name = inputFile.name.split(".")[0]+".qoa";
+        const name = inputFile.name.split(".").slice(0, -1).join(".")+".qoa";
         outputFiles.push({bytes: qoaBytes, name});
       }
     }

--- a/src/handlers/qoi-fu.ts
+++ b/src/handlers/qoi-fu.ts
@@ -120,7 +120,7 @@ class qoiFuHandler implements FormatHandler {
         const bytesSize = qoiEncoder.getEncodedSize();
         const bytes = new Uint8Array(qoiEncoder.getEncoded().slice(0, bytesSize));
 
-        const name = inputFile.name.split(".")[0] + "." + outputFormat.extension;
+        const name = inputFile.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension;
         outputFiles.push({ bytes, name });
 
       }
@@ -150,7 +150,7 @@ class qoiFuHandler implements FormatHandler {
             blob.arrayBuffer().then(buf => resolve(new Uint8Array(buf)));
           }, outputFormat.mime);
         });
-        const name = inputFile.name.split(".")[0] + "." + outputFormat.extension;
+        const name = inputFile.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension;
         outputFiles.push({ bytes, name });
 
       }

--- a/src/handlers/rename.ts
+++ b/src/handlers/rename.ts
@@ -16,7 +16,7 @@ function renameHandler(name: string, formats: FileFormat[]): FormatHandler {
       outputFormat: FileFormat
     ): Promise<FileData[]> {
       return inputFiles.map(file => {
-        file.name = file.name.split(".")[0] + "." + outputFormat.extension;
+        file.name = file.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension;
         return file;
       });
     }

--- a/src/handlers/sppd.ts
+++ b/src/handlers/sppd.ts
@@ -537,7 +537,7 @@ class sppdHandler implements FormatHandler {
         const encoder = new TextEncoder();
         const string = JSON.stringify(demo, getJsonReplacer(), 2);
         const bytes = encoder.encode(string);
-        const name = inputFile.name.split(".")[0] + ".json";
+        const name = inputFile.name.split(".").slice(0, -1).join(".") + ".json";
         outputFiles.push({ bytes, name });
         continue;
       }
@@ -557,7 +557,7 @@ class sppdHandler implements FormatHandler {
                 blob.arrayBuffer().then(buf => resolve(new Uint8Array(buf)));
               }, outputFormat.mime);
             });
-            const name = inputFile.name.split(".")[0] + "_" + frameIndex + "." + outputFormat.extension;
+            const name = inputFile.name.split(".").slice(0, -1).join(".") + "_" + frameIndex + "." + outputFormat.extension;
             outputFiles.push({ bytes, name });
 
             frameIndex ++;

--- a/src/handlers/svgTrace.ts
+++ b/src/handlers/svgTrace.ts
@@ -34,7 +34,7 @@ class svgTraceHandler implements FormatHandler {
       const blob = new Blob([inputFile.bytes as BlobPart], { type: inputFormat.mime });
       const url = URL.createObjectURL(blob);
       const traced = await imageTracer.imageToSVG(url); // return the full svg string
-      const name = inputFile.name.split(".")[0] + ".svg";
+      const name = inputFile.name.split(".").slice(0, -1).join(".") + ".svg";
       const bytes = encoder.encode(traced);
 
 

--- a/src/handlers/threejs.ts
+++ b/src/handlers/threejs.ts
@@ -106,7 +106,7 @@ class threejsHandler implements FormatHandler {
           blob.arrayBuffer().then(buf => resolve(new Uint8Array(buf)));
         }, outputFormat.mime);
       });
-      const name = inputFile.name.split(".")[0] + "." + outputFormat.extension;
+      const name = inputFile.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension;
       outputFiles.push({ bytes, name });
 
     }

--- a/src/handlers/toon.ts
+++ b/src/handlers/toon.ts
@@ -42,7 +42,7 @@ class toonHandler implements FormatHandler {
           let jsonData = JSON.parse(text);
 
           const toonData = encode(jsonData);
-          const name = file.name.split(".")[0] + ".toon";
+          const name = file.name.split(".").slice(0, -1).join(".") + ".toon";
 
           return {
             name,
@@ -59,7 +59,7 @@ class toonHandler implements FormatHandler {
           const toonData = new TextDecoder().decode(file.bytes);
           const jsonData = JSON.stringify(decode(toonData));
 
-          const name = file.name.split(".")[0] + ".json";
+          const name = file.name.split(".").slice(0, -1).join(".") + ".json";
 
           return {
             name,

--- a/src/handlers/vtf.ts
+++ b/src/handlers/vtf.ts
@@ -849,7 +849,7 @@ class vtfHandler implements FormatHandler {
           blob.arrayBuffer().then(buf => resolve(new Uint8Array(buf)));
         }, outputFormat.mime);
       });
-      const name = inputFile.name.split(".")[0] + "." + outputFormat.extension;
+      const name = inputFile.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension;
       outputFiles.push({ bytes, name });
     }
     return outputFiles;


### PR DESCRIPTION
went through and found every occurrence i could of naive output file naming (e.g. just taking everything before the first dot in the input file name) and replaced it with correct behavior

for example, a handler that would've done this:
`a.b.png` -> `a.mp4`
would've been fixed to be:
`a.b.png` -> `a.b.mp4`