### PR TITLE
Fix OBJ format name

### DIFF
--- a/src/handlers/threejs.ts
+++ b/src/handlers/threejs.ts
@@ -33,7 +33,7 @@ class threejsHandler implements FormatHandler {
       lossless: false
     },
     {
-      name: "Waveform OBJ",
+      name: "Wavefront OBJ",
       format: "obj",
       extension: "obj",
       mime: "model/obj",


### PR DESCRIPTION
Corrects the file format's name defined in the threejs handler to Wavefront OBJ. This makes it consistent with the format name introduced by #555.