### PR TITLE
Draft: Add progress support

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.less">
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <title>Convert to it!</title>
   
@@ -34,18 +34,22 @@
   <div id="format-containers">
 
     <div id="from-container" class="format-container">
-      <h2>Convert from:</h2>
-      <input type="text" id="search-from" class="search" placeholder="Search">
-      <div id="from-list" class="format-list">
+      <div class="format-container-inner">
+        <h2>Convert from:</h2>
+        <input type="text" id="search-from" class="search" placeholder="Search">
+        <div id="from-list" class="format-list">
 
+        </div>
       </div>
     </div>
 
     <div id="to-container" class="format-container">
-      <h2>Convert to:</h2>
-      <input type="text" id="search-to" class="search" placeholder="Search">
-      <div id="to-list" class="format-list">
+      <div class="format-container-inner">
+        <h2>Convert to:</h2>
+        <input type="text" id="search-to" class="search" placeholder="Search">
+        <div id="to-list" class="format-list">
 
+        </div>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -51,7 +51,10 @@
 
   </div>
 
-  <button id="convert-button" class="disabled">Convert</button>
+  <div id="convert-container">
+    <button id="back-button">←</button>
+    <button id="convert-button" class="disabled">Convert</button>
+  </div>
 
   <div id="popup-bg"></div>
   <div id="popup">

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/opentype.js": "^1.3.9",
     "electron": "^40.6.0",
     "electron-builder": "^26.8.1",
+    "less": "^4.6.4",
     "puppeteer": "^24.36.0",
     "typescript": "~5.9.3",
     "vite": "^7.2.4",

--- a/src/FormatHandler.ts
+++ b/src/FormatHandler.ts
@@ -1,4 +1,6 @@
 
+import type { ConvertContext } from "./progress.js";
+
 /**
  * Definition of file format. Contains format defined constants like mime type and names
  */
@@ -185,13 +187,15 @@ export interface FormatHandler {
    * @param outputFormat Output {@link FileFormat}, the same for all outputs.
    * @param args Optional arguments as a string array.
    * Can be used to perform recursion with different settings.
+   * @param ctx Optional {@link ConvertContext} for progress/log reporting.
    * @returns Array of {@link FileData} entries, one per generated output file.
    */
   doConvert: (
     inputFiles: FileData[],
     inputFormat: FileFormat,
     outputFormat: FileFormat,
-    args?: string[]
+    args?: string[],
+    ctx?: ConvertContext
   ) => Promise<FileData[]>;
 }
 

--- a/src/handlers/FFmpeg.ts
+++ b/src/handlers/FFmpeg.ts
@@ -1,4 +1,5 @@
 import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
+import type { ConvertContext } from "../progress.ts";
 
 import { FFmpeg } from "@ffmpeg/ffmpeg";
 import type { LogEvent } from "@ffmpeg/ffmpeg";
@@ -30,18 +31,18 @@ class FFmpegHandler implements FormatHandler {
   #ffmpeg?: FFmpeg;
 
   #stdout: string = "";
-  handleStdout (log: LogEvent) {
+  #boundStdoutHandler = (log: LogEvent) => {
     this.#stdout += log.message + "\n";
-  }
+  };
   clearStdout () {
     this.#stdout = "";
   }
   async getStdout (callback: () => void | Promise<void>) {
     if (!this.#ffmpeg) return "";
     this.clearStdout();
-    this.#ffmpeg.on("log", this.handleStdout.bind(this));
+    this.#ffmpeg.on("log", this.#boundStdoutHandler);
     await callback();
-    this.#ffmpeg.off("log", this.handleStdout.bind(this));
+    this.#ffmpeg.off("log", this.#boundStdoutHandler);
     return this.#stdout;
   }
 
@@ -268,14 +269,40 @@ class FFmpegHandler implements FormatHandler {
     inputFiles: FileData[],
     inputFormat: FileFormat,
     outputFormat: FileFormat,
-    args?: string[]
+    args?: string[],
+    ctx?: ConvertContext
   ): Promise<FileData[]> {
 
     if (!this.#ffmpeg) {
       throw "Handler not initialized.";
     }
 
+    ctx?.throwIfAborted();
+    ctx?.log("Reloading FFmpeg...");
     await this.reloadFFmpeg();
+
+    if (ctx) {
+      const abortHandler = () => {
+        ctx.log("Abort signal received — terminating FFmpeg.", "error");
+        this.terminateFFmpeg();
+      };
+      ctx.signal.addEventListener("abort", abortHandler, { once: true });
+
+      this.#ffmpeg.on("log", ({ message, type }) => {
+        let level: "log" | "error" | "warn" = "log";
+        if (type === "stderr") level = "warn";
+        ctx.log(message, level);
+      });
+
+      this.#ffmpeg.on("progress", ({ progress, time }) => {
+        if (!Number.isFinite(progress) || progress < 0) {
+          const seconds = time / 1_000_000;
+          ctx.progress(`Transcoding... (${seconds.toFixed(1)}s processed)`, p => Math.min(0.95, p + 0.001));
+        } else {
+          ctx.progress(`Transcoding...`, Math.max(0, Math.min(0.99, progress)));
+        }
+      });
+    }
 
     let forceFPS = 0;
     if (inputFormat.mime === "image/png" || inputFormat.mime === "image/jpeg") {
@@ -284,7 +311,9 @@ class FFmpegHandler implements FormatHandler {
 
     let fileIndex = 0;
     let listString = "";
+    ctx?.log(`Preparing ${inputFiles.length} input files...`);
     for (const file of inputFiles) {
+      ctx?.throwIfAborted();
       const entryName = `file_${fileIndex++}.${inputFormat.extension}`;
       await this.#ffmpeg.writeFile(entryName, new Uint8Array(file.bytes));
       listString += `file '${entryName}'\n`;
@@ -305,34 +334,37 @@ class FFmpegHandler implements FormatHandler {
     if (args) command.push(...args);
     command.push("output");
 
+    ctx?.log(`Executing FFmpeg command: ffmpeg ${command.join(" ")}`);
     const stdout = await this.getStdout(async () => {
       await this.#ffmpeg!.exec(command);
     });
 
+    ctx?.throwIfAborted();
+    ctx?.log("Cleaning up input files...");
     for (let i = 0; i < fileIndex; i ++) {
       const entryName = `file_${i}.${inputFormat.extension}`;
       await this.#ffmpeg.deleteFile(entryName);
     }
 
     if (stdout.includes("Conversion failed!\n")) {
-
-      const oldArgs = args ? args : []
+      ctx?.log("Conversion failed, attempting auto-fix...", "error");
+      const oldArgs = args ?? [];
       if (stdout.includes(" not divisible by") && !oldArgs.includes("-vf")) {
         const division = stdout.split(" not divisible by ")[1].split(" ")[0];
-        return this.doConvert(inputFiles, inputFormat, outputFormat, [...oldArgs, "-vf", `pad=ceil(iw/${division})*${division}:ceil(ih/${division})*${division}`]);
+        return this.doConvert(inputFiles, inputFormat, outputFormat, [...oldArgs, "-vf", `pad=ceil(iw/${division})*${division}:ceil(ih/${division})*${division}`], ctx);
       }
       if (stdout.includes("width and height must be a multiple of") && !oldArgs.includes("-vf")) {
         const division = stdout.split("width and height must be a multiple of ")[1].split(" ")[0].split("")[0];
-        return this.doConvert(inputFiles, inputFormat, outputFormat, [...oldArgs, "-vf", `pad=ceil(iw/${division})*${division}:ceil(ih/${division})*${division}`]);
+        return this.doConvert(inputFiles, inputFormat, outputFormat, [...oldArgs, "-vf", `pad=ceil(iw/${division})*${division}:ceil(ih/${division})*${division}`], ctx);
       }
       if (stdout.includes("Valid sizes are") && !oldArgs.includes("-s")) {
         const newSize = stdout.split("Valid sizes are ")[1].split(".")[0].split(" ").pop();
         if (typeof newSize !== "string") throw stdout;
-        return this.doConvert(inputFiles, inputFormat, outputFormat, [...oldArgs, "-s", newSize]);
+        return this.doConvert(inputFiles, inputFormat, outputFormat, [...oldArgs, "-s", newSize], ctx);
       }
       if (stdout.includes("does not support that sample rate, choose from (") && !oldArgs.includes("-ar")) {
         const acceptedBitrate = stdout.split("does not support that sample rate, choose from (")[1].split(", ")[0];
-        return this.doConvert(inputFiles, inputFormat, outputFormat, [...oldArgs, "-ar", acceptedBitrate]);
+        return this.doConvert(inputFiles, inputFormat, outputFormat, [...oldArgs, "-ar", acceptedBitrate], ctx);
       }
 
       throw stdout;
@@ -340,15 +372,17 @@ class FFmpegHandler implements FormatHandler {
 
     let bytes: Uint8Array;
 
-    // Validate that output file exists before attempting to read
+    ctx?.log("Reading output file...");
     let fileData;
     try {
       fileData = await this.#ffmpeg.readFile("output");
     } catch (e) {
+      ctx?.log(`Output file not created: ${e}`, "error");
       throw `Output file not created: ${e}`;
     }
 
     if (!fileData || (fileData instanceof Uint8Array && fileData.length === 0)) {
+      ctx?.log("FFmpeg failed to produce output file", "error");
       throw "FFmpeg failed to produce output file";
     }
     if (!(fileData instanceof Uint8Array)) {
@@ -363,6 +397,9 @@ class FFmpegHandler implements FormatHandler {
 
     const baseName = inputFiles[0].name.split(".").slice(0, -1).join(".");
     const name = baseName + "." + outputFormat.extension;
+
+    ctx?.progress("Conversion complete!", 1);
+    ctx?.log(`Successfully converted to ${name} (${bytes.length} bytes)`);
 
     return [{ bytes, name }];
 

--- a/src/handlers/ImageMagick.ts
+++ b/src/handlers/ImageMagick.ts
@@ -11,6 +11,7 @@ import mime from "mime";
 import normalizeMimeType from "../normalizeMimeType.ts";
 import CommonFormats from "src/CommonFormats.ts";
 import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
+import type { ConvertContext } from "../progress.ts";
 
 class ImageMagickHandler implements FormatHandler {
 
@@ -83,7 +84,9 @@ class ImageMagickHandler implements FormatHandler {
   async doConvert (
     inputFiles: FileData[],
     inputFormat: FileFormat,
-    outputFormat: FileFormat
+    outputFormat: FileFormat,
+    args?: string[],
+    ctx?: ConvertContext
   ): Promise<FileData[]> {
 
     const inputMagickFormat = inputFormat.internal as MagickFormat;
@@ -92,30 +95,49 @@ class ImageMagickHandler implements FormatHandler {
     const inputSettings = new MagickReadSettings();
     inputSettings.format = inputMagickFormat;
 
+    ctx?.log(`Initialising ImageMagick for ${inputFiles.length} files...`);
 
     const bytes: Uint8Array = await new Promise(resolve => {
       MagickImageCollection.use(outputCollection => {
+        let processedCount = 0;
         for (const inputFile of inputFiles) {
-           if (inputFormat.format === "rgb") {
-             // Guess how big the Image should be
-             inputSettings.width = Math.sqrt(inputFile.bytes.length / 3);
-             inputSettings.height = inputSettings.width;
-           }
+          const progressMsg = `Reading ${inputFile.name}...`;
+          ctx?.progress(progressMsg, processedCount / inputFiles.length);
+          ctx?.log(progressMsg);
+
+          if (inputFormat.format === "rgb") {
+            // Guess how big the Image should be
+            inputSettings.width = Math.sqrt(inputFile.bytes.length / 3);
+            inputSettings.height = inputSettings.width;
+            ctx?.log(`Detected RAW RGB format. Guessed dimensions: ${inputSettings.width}x${inputSettings.height}`, "debug");
+          }
+
           MagickImageCollection.use(fileCollection => {
             fileCollection.read(inputFile.bytes, inputSettings);
+            ctx?.log(`Successfully read ${inputFile.name}. Found ${fileCollection.length} sub-images/frames.`, "debug");
+
+            let frameIndex = 0;
             while (fileCollection.length > 0) {
               const image = fileCollection.shift();
               if (!image) break;
 
-              if(outputFormat.format === "ico" && (image.width > 256 || image.height > 256)) {
+              if (outputFormat.format === "ico" && (image.width > 256 || image.height > 256)) {
+                ctx?.log(`Image ${inputFile.name} frame ${frameIndex} too large for ICO (${image.width}x${image.height}). Resizing to 256x256...`, "warn");
                 const geometry = new MagickGeometry(256, 256);
                 image.resize(geometry);
               }
 
               outputCollection.push(image);
+              frameIndex++;
             }
           });
+          processedCount++;
         }
+
+        const writingMsg = `Encoding output as ${outputFormat.extension}...`;
+        ctx?.progress(writingMsg, 0.9);
+        ctx?.log(writingMsg);
+
         outputCollection.write(outputMagickFormat, (bytes) => {
           resolve(new Uint8Array(bytes));
         });
@@ -124,6 +146,10 @@ class ImageMagickHandler implements FormatHandler {
 
     const baseName = inputFiles[0].name.split(".").slice(0, -1).join(".");
     const name = baseName + "." + outputFormat.extension;
+
+    ctx?.progress("Conversion complete!", 1);
+    ctx?.log(`Successfully converted ${inputFiles.length} files to ${name} (${bytes.length} bytes)`);
+
     return [{ bytes, name }];
 
   }

--- a/src/handlers/pandoc.ts
+++ b/src/handlers/pandoc.ts
@@ -1,4 +1,5 @@
 import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
+import type { ConvertContext } from "../progress.ts";
 import CommonFormats from "src/CommonFormats.ts";
 import mime from "mime";
 import normalizeMimeType from "../normalizeMimeType.ts";
@@ -236,7 +237,9 @@ class pandocHandler implements FormatHandler {
   async doConvert (
     inputFiles: FileData[],
     inputFormat: FileFormat,
-    outputFormat: FileFormat
+    outputFormat: FileFormat,
+    args?: string[],
+    ctx?: ConvertContext
   ): Promise<FileData[]> {
     if (
       !this.ready
@@ -246,7 +249,13 @@ class pandocHandler implements FormatHandler {
 
     const outputFiles: FileData[] = [];
 
+    ctx?.log(`Initialising Pandoc for ${inputFormat.name} -> ${outputFormat.name}...`);
+
+    let i = 0;
     for (const inputFile of inputFiles) {
+      const progressMsg = `Converting ${inputFile.name}...`;
+      ctx?.progress(progressMsg, i / inputFiles.length);
+      ctx?.log(progressMsg);
 
       const files = {
         [inputFile.name]: new Blob([inputFile.bytes as BlobPart])
@@ -267,20 +276,35 @@ class pandocHandler implements FormatHandler {
         options["html-math-method"] = "mathml";
       }
 
-      const { stderr } = await this.convert(options, null, files);
+      const { stderr, warnings } = await this.convert(options, null, files);
 
-      if (stderr) throw stderr;
+      if (stderr) {
+        ctx?.log(`Pandoc Error: ${stderr}`, "error");
+        throw stderr;
+      }
+
+      if (warnings && warnings.length > 0) {
+        for (const warning of warnings) {
+          ctx?.log(`Pandoc Warning: ${JSON.stringify(warning)}`, "warn");
+        }
+      }
 
       const outputBlob = files.output;
-      if (!(outputBlob instanceof Blob)) continue;
+      if (!(outputBlob instanceof Blob)) {
+        ctx?.log(`Pandoc failed to produce output for ${inputFile.name}`, "error");
+        continue;
+      }
 
       const arrayBuffer = await outputBlob.arrayBuffer();
       const bytes = new Uint8Array(arrayBuffer);
       const name = inputFile.name.split(".").slice(0, -1).join(".") + "." + outputFormat.extension;
 
       outputFiles.push({ bytes, name });
-
+      i++;
     }
+
+    ctx?.progress("Conversion complete!", 1);
+    ctx?.log(`Successfully converted ${outputFiles.length} files.`);
 
     return outputFiles;
   }

--- a/src/handlers/sevenZip.ts
+++ b/src/handlers/sevenZip.ts
@@ -5,6 +5,7 @@ import CommonFormats, { Category } from "src/CommonFormats.ts";
 import SevenZip from "7z-wasm";
 import mime from "mime";
 import normalizeMimeType from "src/normalizeMimeType.ts";
+import type { ConvertContext } from "src/progress.ts";
 
 const defaultSevenZipOptions = {
   locateFile: () => "/convert/wasm/7zz.wasm"
@@ -91,7 +92,9 @@ class sevenZipHandler implements FormatHandler {
   async doConvert (
     inputFiles: FileData[],
     inputFormat: FileFormat,
-    outputFormat: FileFormat
+    outputFormat: FileFormat,
+    args?: string[],
+    ctx?: ConvertContext
   ): Promise<FileData[]> {
     const outputFiles: FileData[] = [];
 
@@ -99,13 +102,34 @@ class sevenZipHandler implements FormatHandler {
       throw new Error(`sevenZipHandler cannot convert to ${outputFormat.mime}`);
     }
 
+    let logBuffer = "";
+    const createSevenZip = async () => {
+      return await SevenZip({
+        ...defaultSevenZipOptions,
+        stdout: (c) => {
+          const char = String.fromCharCode(c);
+          if (char === "\n") {
+            ctx?.log(logBuffer, "debug");
+            logBuffer = "";
+          } else {
+            logBuffer += char;
+          }
+        },
+      });
+    };
+
+    ctx?.log(`Initialising SevenZip for ${inputFormat.name} -> ${outputFormat.name}...`);
+
     // handle compressed tars
     if (this.#tarCompressedFormats.includes(inputFormat.internal) 
       || this.#tarCompressedFormats.includes(outputFormat.internal)) {
 
       if (outputFormat.internal === "tar") {
+        let i = 0;
         for (const inputFile of inputFiles) {
-          const sevenZip = await SevenZip(defaultSevenZipOptions);
+          ctx?.progress(`Extracting ${inputFile.name}...`, i / inputFiles.length);
+          ctx?.log(`Extracting ${inputFile.name}...`);
+          const sevenZip = await createSevenZip();
 
           sevenZip.FS.writeFile(inputFile.name, inputFile.bytes);
           sevenZip.callMain(["x", inputFile.name]);
@@ -113,10 +137,14 @@ class sevenZipHandler implements FormatHandler {
           const name = inputFile.name.replace(/\.[^.]+$/, "");
           const bytes = sevenZip.FS.readFile(name);
           outputFiles.push({ bytes, name });
+          i++;
         }
       } else if (inputFormat.internal === "tar") {
+        let i = 0;
         for (const inputFile of inputFiles) {
-          const sevenZip = await SevenZip(defaultSevenZipOptions);
+          ctx?.progress(`Compressing ${inputFile.name}...`, i / inputFiles.length);
+          ctx?.log(`Compressing ${inputFile.name}...`);
+          const sevenZip = await createSevenZip();
           sevenZip.FS.writeFile(inputFile.name, inputFile.bytes);
 
           const name = inputFile.name + `.${outputFormat.extension}`;
@@ -124,41 +152,54 @@ class sevenZipHandler implements FormatHandler {
 
           const bytes = sevenZip.FS.readFile(name);
           outputFiles.push({ bytes, name });
+          i++;
         }
       } else {
         throw new Error(`sevenZipHandler cannot convert from ${inputFormat.mime} to ${outputFormat.mime}`);
       }
       
+      ctx?.progress("Complete!", 1);
       return outputFiles;
     }
 
     if (this.supportedFormats.some(format => format.internal === inputFormat.internal)) {
+      let i = 0;
       for (const inputFile of inputFiles) {
-        const sevenZip = await SevenZip(defaultSevenZipOptions);
+        ctx?.progress(`Processing archive ${inputFile.name}...`, i / inputFiles.length);
+        ctx?.log(`Processing archive ${inputFile.name}...`);
+        const sevenZip = await createSevenZip();
 
         sevenZip.FS.writeFile(inputFile.name, inputFile.bytes);
+        ctx?.log(`Extracting ${inputFile.name} to temporary directory...`, "debug");
         sevenZip.callMain(["x", inputFile.name, `-odata`]);
 
         const name = inputFile.name.replace(/\.[^.]+$/, "") + `.${outputFormat.extension}`;
         sevenZip.FS.chdir("data"); // we need to preserve the structure of the input archive
+        ctx?.log(`Re-archiving contents as ${outputFormat.internal}...`, "debug");
         sevenZip.callMain(["a", "../" + name]);
         sevenZip.FS.chdir("..");
 
         const bytes = sevenZip.FS.readFile(name);
         outputFiles.push({ bytes, name });
+        i++;
       }
     } else {
-      const sevenZip = await SevenZip(defaultSevenZipOptions);
+      ctx?.progress(`Creating ${outputFormat.name}...`, 0.5);
+      ctx?.log(`Creating ${outputFormat.name} from ${inputFiles.length} files...`);
+      const sevenZip = await createSevenZip();
 
       sevenZip.FS.mkdir("data");
       sevenZip.FS.chdir("data");
       for (const inputFile of inputFiles) {
+        ctx?.log(`Adding ${inputFile.name} to archive...`, "debug");
         sevenZip.FS.writeFile(inputFile.name, inputFile.bytes);
       }
 
       const name = inputFiles.length === 1 ? 
         inputFiles[0].name + `.${outputFormat.extension}`
         : `archive.${outputFormat.extension}`;
+      
+      ctx?.log(`Compiling archive ${name}...`);
       sevenZip.callMain(["a", "../" + name]);
       sevenZip.FS.chdir("..");
 
@@ -166,6 +207,8 @@ class sevenZipHandler implements FormatHandler {
       outputFiles.push({ bytes, name });
     }
 
+    ctx?.progress("Complete!", 1);
+    ctx?.log(`SevenZip successfully processed ${inputFiles.length} files.`);
     return outputFiles;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import type { FileFormat, FileData, FormatHandler, ConvertPathNode } from "./For
 import normalizeMimeType from "./normalizeMimeType.js";
 import handlers from "./handlers";
 import { TraversionGraph } from "./TraversionGraph.js";
+import { createConvertContext, createConversionAbortController, resetProgress, setProgress } from "./progress.js";
 
 /** Files currently selected for conversion */
 let selectedFiles: File[] = [];
@@ -363,11 +364,12 @@ ui.modeToggleButton.addEventListener("click", () => {
 
 let deadEndAttempts: ConvertPathNode[][];
 
+let conversionAbortController: AbortController | null = null;
+
 async function attemptConvertPath (files: FileData[], path: ConvertPathNode[]) {
 
   const pathString = path.map(c => c.format.format).join(" → ");
 
-  // Exit early if we've encountered a known dead end
   for (const deadEnd of deadEndAttempts) {
     let isDeadEnd = true;
     for (let i = 0; i < deadEnd.length; i++) {
@@ -382,14 +384,20 @@ async function attemptConvertPath (files: FileData[], path: ConvertPathNode[]) {
     }
   }
 
-  ui.popupBox.innerHTML = `<h2>Finding conversion route...</h2>
-    <p>Trying <b>${pathString}</b>...</p>`;
+  setProgress(`Trying ${pathString}...`, 0);
 
+  const signal = conversionAbortController?.signal;
+
+  const totalSteps = path.length - 1;
   for (let i = 0; i < path.length - 1; i ++) {
+    if (signal?.aborted) return null;
+
     const handler = path[i + 1].handler;
+    const ctx = createConvertContext(handler.name, signal);
     try {
       let supportedFormats = window.supportedFormatCache.get(handler.name);
       if (!handler.ready) {
+        ctx.log(`Initializing ${handler.name}...`);
         await handler.init();
         if (!handler.ready) throw `Handler "${handler.name}" not ready after init.`;
         if (handler.supportedFormats) {
@@ -404,26 +412,29 @@ async function attemptConvertPath (files: FileData[], path: ConvertPathNode[]) {
         && c.format === path[i].format.format
       ) || (handler.supportAnyInput ? path[i].format : undefined);
       if (!inputFormat) throw `Handler "${handler.name}" doesn't support the "${path[i].format.format}" format.`;
+      ctx.log(`Converting ${path[i].format.format} → ${path[i + 1].format.format}`);
+      setProgress(`${handler.name}: ${path[i].format.format} → ${path[i + 1].format.format}`, i / totalSteps);
       files = (await Promise.all([
-        handler.doConvert(files, inputFormat, path[i + 1].format),
-        // Ensure that we wait long enough for the UI to update
+        handler.doConvert(files, inputFormat, path[i + 1].format, undefined, ctx),
         new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
       ]))[0];
+      ctx.log(`Step ${i + 1}/${totalSteps} complete`);
       if (files.some(c => !c.bytes.length)) throw "Output is empty.";
     } catch (e) {
+
+      if (e instanceof DOMException && e.name === "AbortError") {
+        throw e;
+      }
 
       console.log(path.map(c => c.format.format));
       console.error(handler.name, `${path[i].format.format} → ${path[i + 1].format.format}`, e);
 
-      // Dead ends are added both to the graph and to the attempt system.
-      // The graph may still have old paths queued from before they were
-      // marked as dead ends, so we catch that here.
       const deadEndPath = path.slice(0, i + 2);
       deadEndAttempts.push(deadEndPath);
       window.traversionGraph.addDeadEndPath(path.slice(0, i + 2));
 
-      ui.popupBox.innerHTML = `<h2>Finding conversion route...</h2>
-        <p>Looking for a valid path...</p>`;
+      ctx.log(`Dead end: ${path[i].format.format} → ${path[i + 1].format.format}`);
+      setProgress("Looking for a valid path...", 0);
       await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
       return null;
@@ -443,7 +454,7 @@ window.tryConvertByTraversing = async function (
   deadEndAttempts = [];
   window.traversionGraph.clearDeadEndPaths();
   for await (const path of window.traversionGraph.searchPath(from, to, simpleMode)) {
-    // Use exact output format if the target handler supports it
+    if (conversionAbortController?.signal.aborted) return null;
     if (path.at(-1)?.handler === to.handler) {
       path[path.length - 1] = to;
     }
@@ -504,13 +515,16 @@ ui.convertButton.onclick = async function () {
       inputFileData.push({ name: inputFile.name, bytes: inputBytes });
     }
 
-    window.showPopup("<h2>Finding conversion route...</h2>");
-    // Delay for a bit to give the browser time to render
+    resetProgress();
+    conversionAbortController = createConversionAbortController();
+    window.showPopup("");
+    setProgress("Finding conversion route...", 0);
     await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
     const output = await window.tryConvertByTraversing(inputFileData, inputOption, outputOption);
     if (!output) {
       window.hidePopup();
+      if (conversionAbortController?.signal.aborted) return;
       alert("Failed to find conversion route.");
       return;
     }
@@ -527,6 +541,10 @@ ui.convertButton.onclick = async function () {
 
   } catch (e) {
 
+    if (e instanceof DOMException && e.name === "AbortError") {
+      window.hidePopup();
+      return;
+    }
     window.hidePopup();
     alert("Unexpected error while routing:\n" + e);
     console.error(e);

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,8 +23,49 @@ const ui = {
   inputSearch: document.querySelector("#search-from") as HTMLInputElement,
   outputSearch: document.querySelector("#search-to") as HTMLInputElement,
   popupBox: document.querySelector("#popup") as HTMLDivElement,
-  popupBackground: document.querySelector("#popup-bg") as HTMLDivElement
+  popupBackground: document.querySelector("#popup-bg") as HTMLDivElement,
+  formatContainers: document.querySelector("#format-containers") as HTMLDivElement,
+  mobileBackButton: document.querySelector("#back-button") as HTMLButtonElement
 };
+
+// Can be maybe moved to another util file - lmk
+const isMobileView = () => window.matchMedia("(max-width: 800px)").matches;
+
+const isOnMobileToStep = () => ui.formatContainers.classList.contains("mobile-step-to");
+
+const updateMobileConvertButton = () => {
+  if (!isMobileView()) return;
+  const hasFromSelected = !!document.querySelector("#from-list .selected");
+  const hasToSelected = !!document.querySelector("#to-list .selected");
+
+  if (isOnMobileToStep()) {
+    ui.convertButton.textContent = "Convert";
+    ui.convertButton.className = hasToSelected ? "" : "disabled";
+  } else {
+    // Or "Select Output Format" but that was too long
+    ui.convertButton.textContent = "Next";
+    ui.convertButton.className = hasFromSelected ? "" : "disabled";
+  }
+};
+
+/**
+ * Switches view to the format list of possible output formats
+ */
+const showMobileToStep = () => {
+  ui.formatContainers.classList.add("mobile-step-to");
+  ui.formatContainers.scrollIntoView({ behavior: "smooth", block: "start" });
+  updateMobileConvertButton();
+};
+
+/** 
+ * Shows the format list for the file uploaded (from)
+ */
+const showMobileFromStep = () => {
+  ui.formatContainers.classList.remove("mobile-step-to");
+  updateMobileConvertButton();
+};
+
+ui.mobileBackButton.addEventListener("click", showMobileFromStep);
 
 /**
  * Filters a list of butttons to exclude those not matching a substring.
@@ -261,6 +302,12 @@ async function buildOptionList () {
         const previous = targetParent?.getElementsByClassName("selected")?.[0];
         if (previous) previous.className = "";
         event.target.className = "selected";
+
+        if (isMobileView()) {
+          updateMobileConvertButton();
+          return;
+        } 
+
         const allSelected = document.getElementsByClassName("selected");
         if (allSelected.length === 2) {
           ui.convertButton.className = "";
@@ -307,6 +354,7 @@ async function buildOptionList () {
 
 ui.modeToggleButton.addEventListener("click", () => {
   simpleMode = !simpleMode;
+  showMobileFromStep();
   if (simpleMode) {
     ui.modeToggleButton.textContent = "Advanced mode";
     document.body.style.setProperty("--highlight-color", "#1C77FF");
@@ -418,6 +466,13 @@ function downloadFile (bytes: Uint8Array, name: string) {
 }
 
 ui.convertButton.onclick = async function () {
+
+  if (isMobileView() && !isOnMobileToStep()) {
+    const inputButton = document.querySelector("#from-list .selected");
+    if (!inputButton) return;
+    showMobileToStep();
+    return;
+  }
 
   const inputFiles = selectedFiles;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,20 +33,26 @@ const isMobileView = () => window.matchMedia("(max-width: 800px)").matches;
 
 const isOnMobileToStep = () => ui.formatContainers.classList.contains("mobile-step-to");
 
-const updateMobileConvertButton = () => {
-  if (!isMobileView()) return;
-  const hasFromSelected = !!document.querySelector("#from-list .selected");
-  const hasToSelected = !!document.querySelector("#to-list .selected");
+const updateConvertButton = () => {
+  const hasFromSelected = !!ui.inputList.querySelector(".selected");
+  const hasToSelected = !!ui.outputList.querySelector(".selected");
+
+  if (!isMobileView()) {
+    ui.convertButton.textContent = "Convert";
+    ui.convertButton.className = (hasFromSelected && hasToSelected) ? "" : "disabled";
+    return;
+  }
 
   if (isOnMobileToStep()) {
     ui.convertButton.textContent = "Convert";
     ui.convertButton.className = hasToSelected ? "" : "disabled";
   } else {
-    // Or "Select Output Format" but that was too long
     ui.convertButton.textContent = "Next";
     ui.convertButton.className = hasFromSelected ? "" : "disabled";
   }
 };
+
+window.addEventListener("resize", updateConvertButton);
 
 /**
  * Switches view to the format list of possible output formats
@@ -54,7 +60,7 @@ const updateMobileConvertButton = () => {
 const showMobileToStep = () => {
   ui.formatContainers.classList.add("mobile-step-to");
   ui.formatContainers.scrollIntoView({ behavior: "smooth", block: "start" });
-  updateMobileConvertButton();
+  updateConvertButton();
 };
 
 /** 
@@ -62,7 +68,7 @@ const showMobileToStep = () => {
  */
 const showMobileFromStep = () => {
   ui.formatContainers.classList.remove("mobile-step-to");
-  updateMobileConvertButton();
+  updateConvertButton();
 };
 
 ui.mobileBackButton.addEventListener("click", showMobileFromStep);
@@ -303,17 +309,7 @@ async function buildOptionList () {
         if (previous) previous.className = "";
         event.target.className = "selected";
 
-        if (isMobileView()) {
-          updateMobileConvertButton();
-          return;
-        } 
-
-        const allSelected = document.getElementsByClassName("selected");
-        if (allSelected.length === 2) {
-          ui.convertButton.className = "";
-        } else {
-          ui.convertButton.className = "disabled";
-        }
+        updateConvertButton();
       };
 
       if (format.from && addToInputs) {

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,0 +1,131 @@
+export type LogLevel = "log" | "error" | "debug" | "warn";
+
+/** Single log entry from a conversion step. */
+export interface LogEntry {
+  timestamp: number;
+  plugin: string;
+  message: string;
+  level: LogLevel;
+}
+
+/** Context passed to doConvert for progress/log reporting. */
+export interface ConvertContext {
+  /**
+   * Report progress.
+   * @param message - Status message to display.
+   * @param value - Absolute 0–1 value, or updater `(old) => new`.
+   */
+  progress: (message: string, value: number | ((prev: number) => number)) => void;
+  /**
+   * Append a timestamped log entry.
+   * @param message - The log message.
+   * @param level - Log level ('log', 'error', 'debug', 'warn'). Defaults to 'log'.
+   */
+  log: (message: string, level?: LogLevel) => void;
+  /** AbortSignal for cooperative cancellation. */
+  signal: AbortSignal;
+  /** Throws if the signal has been aborted. Call between async steps. */
+  throwIfAborted: () => void;
+}
+
+interface ProgressState {
+  percent: number;
+  message: string;
+  logs: LogEntry[];
+}
+
+const state: ProgressState = { percent: 0, message: "", logs: [] };
+
+let popupEl: HTMLDivElement | null = null;
+
+function getPopup(): HTMLDivElement {
+  popupEl ??= document.querySelector("#popup") as HTMLDivElement;
+  return popupEl;
+}
+
+function renderProgress() {
+  const popup = getPopup();
+  const pct = Math.round(state.percent * 100);
+
+  const logsHtml = state.logs
+    .slice(-50)
+    .map(l => {
+      const time = new Date(l.timestamp).toLocaleTimeString();
+      return `<div class="log-entry log-level-${l.level}"><span class="log-time">${time}</span><span class="log-msg">${l.message}</span></div>`;
+    })
+    .join("");
+
+  const progressHtml = state.percent > 0 ? `
+    <div class="progress-bar-track">
+      <div class="progress-bar-fill" style="width:${pct}%"></div>
+    </div>
+    <p class="progress-percent">${pct}%</p>
+  ` : "";
+
+  popup.innerHTML = `
+    <h2>${state.message || "Converting..."}</h2>
+    ${progressHtml}
+    <div class="log-container">${logsHtml}</div>
+    <button id="cancel-convert" class="cancel-btn">Cancel</button>
+  `;
+
+  const cancelBtn = popup.querySelector("#cancel-convert");
+  if (cancelBtn && currentAbortController) {
+    const ac = currentAbortController;
+    cancelBtn.addEventListener("click", () => ac.abort());
+  }
+
+  const logContainer = popup.querySelector(".log-container");
+  if (logContainer) logContainer.scrollTop = logContainer.scrollHeight;
+}
+
+let currentAbortController: AbortController | null = null;
+
+/**
+ * Create an AbortController for the current conversion run.
+ * Call once per conversion, before any handler steps.
+ */
+export function createConversionAbortController(): AbortController {
+  currentAbortController = new AbortController();
+  return currentAbortController;
+}
+
+/**
+ * Create a {@link ConvertContext} scoped to a specific plugin.
+ * @param pluginName - Handler name for log attribution.
+ * @param signal - AbortSignal for cooperative cancellation.
+ */
+export function createConvertContext(pluginName: string, signal?: AbortSignal): ConvertContext {
+  const fallbackAC = new AbortController();
+  const sig = signal ?? fallbackAC.signal;
+  return {
+    progress(message, value) {
+      state.message = message;
+      state.percent = typeof value === "function" ? value(state.percent) : value;
+      state.percent = Math.max(0, Math.min(1, state.percent));
+      renderProgress();
+    },
+    log(message, level = "log") {
+      state.logs.push({ timestamp: Date.now(), plugin: pluginName, message, level });
+      renderProgress();
+    },
+    signal: sig,
+    throwIfAborted() {
+      if (sig.aborted) throw new DOMException("Conversion cancelled", "AbortError");
+    }
+  };
+}
+
+/** Reset progress state (call before starting a new conversion). */
+export function resetProgress() {
+  state.percent = 0;
+  state.message = "";
+  state.logs = [];
+}
+
+/** Set top-level progress message and value without a ConvertContext. */
+export function setProgress(message: string, percent: number) {
+  state.message = message;
+  state.percent = Math.max(0, Math.min(1, percent));
+  renderProgress();
+}

--- a/style.css
+++ b/style.css
@@ -131,11 +131,18 @@ button.selected {
   font-weight: bold;
 }
 
-#convert-button {
+#convert-container {
   position: fixed;
   left: 50%;
   bottom: 5%;
   transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 10;
+}
+
+#convert-button {
   font-size: 1.5rem;
   padding: 10px 20px;
   border: 0;
@@ -148,6 +155,10 @@ button.selected {
 .disabled {
   filter: grayscale(1);
   pointer-events: none;
+}
+
+#back-button {
+  display: none;
 }
 
 #popup-bg {
@@ -207,4 +218,30 @@ button.selected {
     font-size: 0.8rem;
     padding: 10px;
   }
+
+  #format-containers #to-container {
+    display: none;
+  }
+  #format-containers.mobile-step-to #from-container {
+    display: none;
+  }
+  #format-containers.mobile-step-to #to-container {
+    display: flex;
+  }
+
+  #format-containers.mobile-step-to ~ #convert-container #back-button {
+    display: block;
+    font-size: 1.5rem;
+    padding: 10px 14px;
+    border: 0;
+    border-radius: 10px;
+    background-color: var(--highlight-color);
+    color: white;
+    cursor: pointer;
+    line-height: 1;
+  }
+  #back-button:active {
+    opacity: 0.8;
+  }
 }
+

--- a/style.less
+++ b/style.less
@@ -178,7 +178,6 @@ button.selected {
   padding: .5em 1em;
   box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   border: 2px solid #0003;
-  transition: transform 0.2s cubic-bezier(.27,.43,.66,1.44), box-shadow .4s ease;
   &:hover {
     box-shadow: 0 4px 6px -1px var(--highlight-color-transparent), 0 2px 4px -2px var(--highlight-color-transparent);
     transform: translateY(-2px);
@@ -204,7 +203,6 @@ button {
 #back-button {
   display: none;
   padding: .6em !important;
-  transition: transform 0.2s cubic-bezier(.27,.43,.66,1.44);
   &:hover {
     transform: translateY(-2px);
   }
@@ -215,6 +213,13 @@ button {
 
 #convert-button, #back-button {
   border-radius: 10px;
+  opacity: 1;
+  transition: opacity .4s ease, transform 0.2s cubic-bezier(.27,.43,.66,1.44), box-shadow .4s ease;
+}
+
+body:has(#popup-bg:not([style*='display: none'])) :is(#convert-button, #back-button){
+  transform: translateY(5px);
+  opacity: 0;
 }
 
 #popup-bg {

--- a/style.less
+++ b/style.less
@@ -1,7 +1,14 @@
+@accent: #0007;
+
+* {
+  box-sizing: border-box;
+  font-family: system-ui, sans-serif;
+}
+
 body {
   margin: 0;
-  font-family: sans-serif;
   --highlight-color: #1C77FF;
+  --highlight-color-transparent: color-mix(in srgb, var(--highlight-color), transparent 70%);
 }
 
 #file-input {
@@ -77,7 +84,11 @@ body {
   align-items: center;
   width: 50vw;
   min-height: 70vh;
-  padding: 0.8em 7em;
+  padding: 0.8em 2em;
+}
+
+.format-container-inner {
+  max-width: 500px;
 }
 .format-container h2 {
   text-align: center;
@@ -92,9 +103,10 @@ body {
 }
 
 .search {
+  width: 100%;
+  padding: 0.8em 1em;
   text-align: center;
   margin-bottom: 30px;
-  padding: 10px 20px;
   border: 0;
   border-radius: 5px;
   outline: none;
@@ -104,25 +116,41 @@ body {
 .format-list {
   display: flex;
   flex-flow: column nowrap;
+  gap: 1em;
   width: 100%;
   align-items: center;
   background-color: white;
   border-radius: 10px;
-  padding: 30px;
+  padding: 1.5em;
   margin-bottom: 5vw;
 }
 
 .format-list button {
-  width: 80%;
-  margin: 5px 0;
-  padding: 10px;
-  color: black;
-  background-color: lightgray;
-  border: 0;
-  border-radius: 10px;
-  font-family: monospace;
-  word-break: break-word;
-  cursor: pointer;
+  width: 100%;
+  font-family: 'Nimbus Mono PS', 'Courier New', monospace;
+  @border-col: lighten(@accent, 20);
+  @shiftdown: 3px;
+  @shadow1: 0 @shiftdown 0 2px @border-col;
+  @border-shadow: 0 0 0 2px @border-col;
+  border-radius: 4px;
+  outline: none;
+  border: none;
+  padding: .7em 1.3em;
+  
+  box-shadow: @shadow1, @border-shadow;
+  transition:
+    box-shadow 0.1s ease-out,
+    transform 0.1s ease;
+  &:hover {
+    @shadow1: 0 3px 0 2px @border-col;
+    box-shadow: @shadow1, @border-shadow;
+    transform: translateY(@shiftdown);
+  }
+  &:active {
+    @shadow1: inset 3px 3px 0 2px @border-col;
+    box-shadow: @shadow1, @border-shadow;
+    transform: translateY(@shiftdown);
+  }
 }
 
 button.selected {
@@ -143,13 +171,29 @@ button.selected {
 }
 
 #convert-button {
-  font-size: 1.5rem;
-  padding: 10px 20px;
-  border: 0;
-  border-radius: 10px;
-  background-color: var(--highlight-color);
-  color: white;
-  cursor: pointer;
+  background: white;
+  font-weight: 600;
+  color: #444;
+  font-size: 1.5em;
+  padding: .5em 1em;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  border: 2px solid #0003;
+  transition: transform 0.2s cubic-bezier(.27,.43,.66,1.44), box-shadow .4s ease;
+  &:hover {
+    box-shadow: 0 4px 6px -1px var(--highlight-color-transparent), 0 2px 4px -2px var(--highlight-color-transparent);
+    transform: translateY(-2px);
+  }
+  &:active {
+    transform: scale(0.99);
+  }
+  &.disabled {
+    background: #eee;
+    color: #777;
+  }
+}
+
+button {
+  cursor: pointer !important;
 }
 
 .disabled {
@@ -159,6 +203,18 @@ button.selected {
 
 #back-button {
   display: none;
+  padding: .6em !important;
+  transition: transform 0.2s cubic-bezier(.27,.43,.66,1.44);
+  &:hover {
+    transform: translateY(-2px);
+  }
+  &:active {
+    transform: scale(0.99);
+  }
+}
+
+#convert-button, #back-button {
+  border-radius: 10px;
 }
 
 #popup-bg {
@@ -234,7 +290,6 @@ button.selected {
     font-size: 1.5rem;
     padding: 10px 14px;
     border: 0;
-    border-radius: 10px;
     background-color: var(--highlight-color);
     color: white;
     cursor: pointer;

--- a/style.less
+++ b/style.less
@@ -43,22 +43,26 @@ body {
   pointer-events: none;
 }
 
-#side-panel button {
+.panel-button(@accent) {
   font-size: 1rem;
   width: 100%;
   padding: 10px 20px;
   border: 0;
   border-radius: 10px;
   background-color: white;
-  color: var(--highlight-color);
+  color: @accent;
   font-weight: bold;
   cursor: pointer;
   box-shadow: 0 5px 0 0 rgba(169, 169, 169, 0.4);
   pointer-events: all;
+  &:active {
+    transform: translateY(5px);
+    box-shadow: 0 0 0 0;
+  }
 }
-#side-panel button:active {
-  transform: translateY(5px);
-  box-shadow: 0 0 0 0;
+
+#side-panel button {
+  .panel-button(var(--highlight-color));
 }
 
 #commit-id {
@@ -235,6 +239,8 @@ body:has(#popup-bg:not([style*='display: none'])) :is(#convert-button, #back-but
   left: 50%;
   top: 50%;
   width: 20vw;
+  min-width: 320px;
+  max-width: 90vw;
   transform: translate(-50%, -50%);
   background-color: white;
   padding: 15px;
@@ -251,6 +257,67 @@ body:has(#popup-bg:not([style*='display: none'])) :is(#convert-button, #back-but
   color: black;
   cursor: pointer;
 }
+
+.cancel-btn {
+  .panel-button(#dc2626);
+  margin-top: 10px;
+}
+
+.progress-bar-track {
+  width: 100%;
+  height: 8px;
+  background: #e0e0e0;
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 12px 0 4px;
+}
+.progress-bar-fill {
+  height: 100%;
+  background: var(--highlight-color);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+  min-width: 0;
+}
+.progress-percent {
+  font-size: 0.85rem;
+  color: #666;
+  margin: 2px 0 8px;
+}
+
+.log-container {
+  max-height: 120px;
+  overflow-y: auto;
+  text-align: left;
+  font-size: 0.75rem;
+  font-family: 'Nimbus Mono PS', 'Courier New', monospace;
+  background: #f5f5f5;
+  border-radius: 6px;
+  padding: 6px 8px;
+  margin-top: 8px;
+  &:empty {
+    display: none;
+  }
+}
+.log-entry {
+  display: flex;
+  gap: 6px;
+  padding: 2px 0;
+  border-bottom: 1px solid #e8e8e8;
+  &:last-child {
+    border-bottom: none;
+  }
+}
+.log-time {
+  color: #999;
+  flex-shrink: 0;
+}
+.log-msg {
+  color: #333;
+  word-break: break-word;
+}
+.log-level-error .log-msg { color: #d32f2f; font-weight: 500; }
+.log-level-warn .log-msg { color: #ed6c02; }
+.log-level-debug .log-msg { color: #666; font-style: italic; }
 
 @media only screen and (max-width: 800px) {
   #drop-hint-text {


### PR DESCRIPTION
Draft for adding progress support and abort signal, handlers get passed in doConvert. New param for doConvert is ConvertContext:
```js
/** Context passed to doConvert for progress/log reporting. */
export interface ConvertContext {
  /**
   * Report progress.
   * @param message - Status message to display.
   * @param value - Absolute 0–1 value, or updater `(old) => new`.
   */
  progress: (message: string, value: number | ((prev: number) => number)) => void;
  /**
   * Append a timestamped log entry.
   * @param message - The log message.
   * @param level - Log level ('log', 'error', 'debug', 'warn'). Defaults to 'log'.
   */
  log: (message: string, level?: LogLevel) => void;
  /** AbortSignal for cooperative cancellation. */
  signal: AbortSignal;
  /** Throws if the signal has been aborted. Call between async steps. */
  throwIfAborted: () => void;
}
```

This allows in doConvert to for instance at convenient times `ctx.throwIfAborted()` or `ctx.progress("Transcoding...", 0.5)`