### PR TITLE
Desktop: Don't include `node_modules` in app.asar

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     },
     "files": [
       "dist/**/*",
-      "src/electron.cjs"
+      "src/electron.cjs",
+      "!node_modules/**/*"
     ],
     "win": {
       "target": "nsis"


### PR DESCRIPTION
Since we're using Vite (which bundles everything) this folder doesn't need to be included.

Tested this by building the Mac app; this reduces the total size from 831.2 mb to 444.8 mb. 386.4 mb saved!
