### PR TITLE
Added .sh files to the allowed text based formats

### DIFF
--- a/src/handlers/rename.ts
+++ b/src/handlers/rename.ts
@@ -125,7 +125,8 @@ export const renameTxtHandler = renameHandler("renametxt", [
   CommonFormats.TEXT.builder("text").allowTo(),
   CommonFormats.JSON.builder("json").allowFrom(),
   CommonFormats.XML.builder("xml").allowFrom(),
-  CommonFormats.YML.builder("yaml").allowFrom()
+  CommonFormats.YML.builder("yaml").allowFrom(),
+  CommonFormats.SH.builder("sh").allowFrom()
 ]);
 /// handler for renaming json-based formats
 export const renameJsonHandler = renameHandler("renamejson", [


### PR DESCRIPTION
Very small change, but without it .sh files are almost completely unsupported (or very cumbersome), even though they are basically text files.