### PR TITLE
add "alternate" mime support for message/coffeepot

### DIFF
--- a/src/normalizeMimeType.ts
+++ b/src/normalizeMimeType.ts
@@ -40,6 +40,7 @@ function normalizeMimeType (mime: string) {
     case "text/json5": return "application/json5";
     case "application/x-json5": return "application/json5";
     case "video/x-ms-wmv": return "video/x-ms-asf";
+    case "application/coffee-pot-command": return "message/coffeepot";
   }
   return mime;
 }

--- a/src/normalizeMimeType.ts
+++ b/src/normalizeMimeType.ts
@@ -40,7 +40,7 @@ function normalizeMimeType (mime: string) {
     case "text/json5": return "application/json5";
     case "application/x-json5": return "application/json5";
     case "video/x-ms-wmv": return "video/x-ms-asf";
-    case "application/coffee-pot-command": return "message/coffeepot";
+    case "application/coffee-pot-command": return "message/coffeepot"; // Not required, but just in case
   }
   return mime;
 }


### PR DESCRIPTION
in the rfc `message/coffeepot` is specified in, there is a known erratum which accidentally mentions the type `application/coffee-pot-command`. since the erratum occurs earlier than the first actual mention of `message/coffeepot`, people are likely to use it accidentally. so just in case that happens, i added a case to `NormalizeMimeType.ts`