### PR TITLE
Include parentheticals in format names by default

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -245,12 +245,7 @@ async function buildOptionList () {
       const formatDescriptor = format.format.toUpperCase();
       if (simpleMode) {
         // Hide any handler-specific information in simple mode
-        const cleanName = format.name
-          .split("(").join(")").split(")")
-          .filter((_, i) => i % 2 === 0)
-          .filter(c => c != "")
-          .join(" ");
-        newOption.appendChild(document.createTextNode(`${formatDescriptor} - ${cleanName} (${format.mime})`));
+        newOption.appendChild(document.createTextNode(`${formatDescriptor} - ${format.name} (${format.mime})`));
       } else {
         newOption.appendChild(document.createTextNode(`${formatDescriptor} - ${format.name} (${format.mime}) ${handler.name}`));
       }


### PR DESCRIPTION
In main.ts, code removes parenthetical portions of a format's name, with the stated reason being to remove "handler-specific information". Having a look through the formats currently supported, I can't see any for which this is actually the case. Format names seem to always use parentheticals as clarification, for example, to specify an acronym, or a specific sub-format. A few of these—for example, the N64 rom formats—are useful information a user might want to know, and removing it leaves 3 formats with identical names, only differentiated by their extension.

If there are indeed cases where the parenthetical is handler-specific, I think there's a better way of handling this than just removing all parentheticals outright.