### PR TITLE
Change example handler in README to use "Category." for categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Below is a super barebones handler that does absolutely nothing. You can use thi
 // file: dummy.ts
 
 import type { FileData, FileFormat, FormatHandler } from "../FormatHandler.ts";
-import CommonFormats from "src/CommonFormats.ts";
+import CommonFormats, { Category } from "src/CommonFormats.ts";
 
 class dummyHandler implements FormatHandler {
 
@@ -118,7 +118,7 @@ class dummyHandler implements FormatHandler {
         from: false,
         to: false,
         internal: "gif",
-        category: ["image", "video"],
+        category: [Category.IMAGE, CATEGORY.VIDEO], // See src/CommonFormats.ts for valid categories
         lossless: false
       },
     ];


### PR DESCRIPTION
As it says on the tin. This seems to be what most handlers (and CommonFormats.ts itself, of course) use, and is IMHO what should be canonical, due to it being more resistant to typos and allowing us to have a central list of all categories.