### PR TITLE
Prevent wad.ts from claiming a zip -> json conversion.

### DIFF
--- a/src/handlers/wad.ts
+++ b/src/handlers/wad.ts
@@ -172,7 +172,7 @@ class wadHandler implements FormatHandler {
                 }
             }
 
-        } else if (inputFormat.internal === "zip") {
+        } else if (inputFormat.internal === "zip" && outputFormat.internal === "wad") {
             // ZIP → WAD: each zip entry becomes a lump
             for (const file of inputFiles) {
                 const baseName = file.name.replace(/\.zip$/i, "");
@@ -227,6 +227,9 @@ class wadHandler implements FormatHandler {
                 const wadBytes = this.buildWAD(lumps, wadType);
                 outputFiles.push({ bytes: wadBytes, name: baseName + ".wad" });
             }
+        }
+        else {
+            throw new Error("Invalid input-output.");
         }
 
         return outputFiles;


### PR DESCRIPTION
Currently, wad.ts can try to convert a .zip to a .json and claim it does it successfully, but actually outputs a .wad. This change fixes that bug.