### PR TITLE
Add .mts (AVCHD) and .m2ts (Blu-ray) input support to FFmpeg handler

### DIFF
--- a/src/handlers/FFmpeg.ts
+++ b/src/handlers/FFmpeg.ts
@@ -236,6 +236,32 @@ class FFmpegHandler implements FormatHandler {
       category: "video"
     });
 
+    // Add .mts (AVCHD) support - camcorder footage using the MPEG-TS container.
+    // FFmpeg auto-discovers "mpegts" but assigns the ".ts" extension, leaving
+    // ".mts" files (JVC, Sony, Panasonic AVCHD camcorders) unrecognised.
+    this.supportedFormats.push({
+      name: "AVCHD Video",
+      format: "mts",
+      extension: "mts",
+      mime: "video/mp2t",
+      from: true,
+      to: false,
+      internal: "mpegts",
+      category: "video"
+    });
+
+    // Add .m2ts (Blu-ray BDMV) support - same MPEG-TS container, different extension.
+    this.supportedFormats.push({
+      name: "Blu-ray BDMV Video",
+      format: "m2ts",
+      extension: "m2ts",
+      mime: "video/mp2t",
+      from: true,
+      to: false,
+      internal: "mpegts",
+      category: "video"
+    });
+
     // Normalize Bink metadata to ensure ".bik" files are detected by extension.
     const binkFormats = this.supportedFormats.filter(f =>
       f.internal === "bink"


### PR DESCRIPTION
## Summary

- FFmpeg's format auto-discovery maps the `mpegts` demuxer to the `.ts` extension, leaving `.mts` (AVCHD camcorders) and `.m2ts` (Blu-ray BDMV) files unrecognised
- Adds two explicit format entries in the manual fine-tuning section, following the same pattern used for `.wmv` (→ `asf`) and `.qta` (→ `mov`)
- Both entries delegate to the existing `mpegts` demuxer with `to: false` — converting *to* AVCHD transport stream is covered by the auto-discovered `.ts` entry

## Test plan

- [ ] Drop a `.mts` file from an AVCHD camcorder (JVC, Sony, Panasonic) into the converter — it should now be recognised and convert to MP4/WebM/etc.
- [ ] Drop a `.m2ts` file from a Blu-ray rip — same
- [ ] Verify `.ts` files (regular MPEG-TS) still work as before
- [ ] Verify no regression on other FFmpeg-handled formats (WMV, MOV, MP4, etc.)

## Notes

> I used Claude Code to help write this PR. I understand every line of the change: it's two `push()` calls adding format metadata objects, identical in structure to the existing `.wmv` and `.qta` entries already in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)