### PR TITLE
desktop: Set executableName

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "build": {
     "appId": "com.p2r3.convert",
+    "executableName": "ConvertToIt",
     "directories": {
       "output": "release"
     },


### PR DESCRIPTION
Fixes `productFilename contains characters that cannot be safely used in file paths` when trying to build the desktop application (Log for failed build: https://github.com/p2r3/convert/actions/runs/27539059463/job/81395818359).