### PR TITLE
Fix example handler typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ class dummyHandler implements FormatHandler {
       from: false,
       to: false,
       internal: "gif",
-      category: [Category.IMAGE, CATEGORY.VIDEO], // See src/CommonFormats.ts for valid categories
+      category: [Category.IMAGE, Category.VIDEO], // See src/CommonFormats.ts for valid categories
       lossless: false
     },
   ];


### PR DESCRIPTION
The example handler contained a typo where one instance of `Category` was spelt out as `CATEGORY`, which points to an unused identifier. This change fixes that typo, so pasting it in a new file won't result in issues related to that.